### PR TITLE
sorter+ghostbuster v0

### DIFF
--- a/data/hwToLogicLayer_721.xml
+++ b/data/hwToLogicLayer_721.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <OMTF xmlns:xi="http://www.w3.org/2001/XInclude">
 
-<GlobalData minPdfVal="0.001" nPdfAddrBits="7" nPdfValBits="6" nHitsPerLayer="6" nPhiBits="10" nPhiBins="4096" nRefHits="128" nTestRefHits="4"/>
+<GlobalData minPdfVal="0.001" nPdfAddrBits="7" nPdfValBits="6" nHitsPerLayer="6" nPhiBits="10" nPhiBins="4096" nRefHits="128" nTestRefHits="5"/>
 
 <LayerMap hwNumber = "101" logicNumber = "0"  bendingLayer = "0" connectedToLayer="1"/>
 <LayerMap hwNumber = "1101" logicNumber = "1" bendingLayer = "1" connectedToLayer="0"/>

--- a/data/hwToLogicLayer_721.xml
+++ b/data/hwToLogicLayer_721.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <OMTF xmlns:xi="http://www.w3.org/2001/XInclude">
 
-<GlobalData minPdfVal="0.001" nPdfAddrBits="7" nPdfValBits="6" nHitsPerLayer="6" nPhiBits="10" nPhiBins="4096" nRefHits="128" nTestRefHits="5"/>
+<GlobalData minPdfVal="0.001" nPdfAddrBits="7" nPdfValBits="6" nHitsPerLayer="6" nPhiBits="10" nPhiBins="4096" nRefHits="128" nTestRefHits="4"/>
 
 <LayerMap hwNumber = "101" logicNumber = "0"  bendingLayer = "0" connectedToLayer="1"/>
 <LayerMap hwNumber = "1101" logicNumber = "1" bendingLayer = "1" connectedToLayer="0"/>

--- a/data/hwToLogicLayer_721.xml
+++ b/data/hwToLogicLayer_721.xml
@@ -32,7 +32,7 @@
 <RefLayerMap refLayer="7" logicNumber ="14"/>
 
 
-   <Processor iProcessor="0">
+     <Processor iProcessor="0">
     <RefLayer iGlobalPhiStart="-90" iRefLayer="0"/>
     <RefLayer iGlobalPhiStart="-178" iRefLayer="1"/>
     <RefLayer iGlobalPhiStart="-130" iRefLayer="2"/>
@@ -42,18 +42,133 @@
     <RefLayer iGlobalPhiStart="-100" iRefLayer="6"/>
     <RefLayer iGlobalPhiStart="-138" iRefLayer="7"/>
     <RefHit iInput="0" iPhiMax="-311" iPhiMin="-423" iRefHit="0" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-399" iPhiMin="-511" iRefHit="1" iRefLayer="1" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-351" iPhiMin="-463" iRefHit="2" iRefLayer="2" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-280" iPhiMin="-392" iRefHit="3" iRefLayer="3" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-280" iPhiMin="-392" iRefHit="4" iRefLayer="3" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-281" iPhiMin="-393" iRefHit="5" iRefLayer="4" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-281" iPhiMin="-393" iRefHit="6" iRefLayer="4" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-322" iPhiMin="-434" iRefHit="7" iRefLayer="5" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-322" iPhiMin="-434" iRefHit="8" iRefLayer="5" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-321" iPhiMin="-433" iRefHit="9" iRefLayer="6" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-321" iPhiMin="-433" iRefHit="10" iRefLayer="6" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-359" iPhiMin="-471" iRefHit="11" iRefLayer="7" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-359" iPhiMin="-471" iRefHit="12" iRefLayer="7" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-311" iPhiMin="-423" iRefHit="1" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-198" iPhiMin="-310" iRefHit="2" iRefLayer="0" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-198" iPhiMin="-310" iRefHit="3" iRefLayer="0" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-85" iPhiMin="-197" iRefHit="4" iRefLayer="0" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-85" iPhiMin="-197" iRefHit="5" iRefLayer="0" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="28" iPhiMin="-84" iRefHit="6" iRefLayer="0" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="28" iPhiMin="-84" iRefHit="7" iRefLayer="0" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="141" iPhiMin="29" iRefHit="8" iRefLayer="0" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="141" iPhiMin="29" iRefHit="9" iRefLayer="0" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="254" iPhiMin="142" iRefHit="10" iRefLayer="0" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="254" iPhiMin="142" iRefHit="11" iRefLayer="0" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-399" iPhiMin="-511" iRefHit="12" iRefLayer="1" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-399" iPhiMin="-511" iRefHit="13" iRefLayer="1" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-286" iPhiMin="-398" iRefHit="14" iRefLayer="1" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-286" iPhiMin="-398" iRefHit="15" iRefLayer="1" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-173" iPhiMin="-285" iRefHit="16" iRefLayer="1" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-173" iPhiMin="-285" iRefHit="17" iRefLayer="1" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="-60" iPhiMin="-172" iRefHit="18" iRefLayer="1" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="-60" iPhiMin="-172" iRefHit="19" iRefLayer="1" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="53" iPhiMin="-59" iRefHit="20" iRefLayer="1" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="53" iPhiMin="-59" iRefHit="21" iRefLayer="1" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="166" iPhiMin="54" iRefHit="22" iRefLayer="1" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="166" iPhiMin="54" iRefHit="23" iRefLayer="1" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-351" iPhiMin="-463" iRefHit="24" iRefLayer="2" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-351" iPhiMin="-463" iRefHit="25" iRefLayer="2" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-238" iPhiMin="-350" iRefHit="26" iRefLayer="2" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-238" iPhiMin="-350" iRefHit="27" iRefLayer="2" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-125" iPhiMin="-237" iRefHit="28" iRefLayer="2" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-125" iPhiMin="-237" iRefHit="29" iRefLayer="2" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="-12" iPhiMin="-124" iRefHit="30" iRefLayer="2" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="-12" iPhiMin="-124" iRefHit="31" iRefLayer="2" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="101" iPhiMin="-11" iRefHit="32" iRefLayer="2" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="101" iPhiMin="-11" iRefHit="33" iRefLayer="2" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="214" iPhiMin="102" iRefHit="34" iRefLayer="2" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="214" iPhiMin="102" iRefHit="35" iRefLayer="2" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-280" iPhiMin="-392" iRefHit="36" iRefLayer="3" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-280" iPhiMin="-392" iRefHit="37" iRefLayer="3" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-167" iPhiMin="-279" iRefHit="38" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-167" iPhiMin="-279" iRefHit="39" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-167" iPhiMin="-279" iRefHit="40" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="3" iPhiMax="-167" iPhiMin="-279" iRefHit="41" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-54" iPhiMin="-166" iRefHit="42" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="3" iPhiMax="-54" iPhiMin="-166" iRefHit="43" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="-54" iPhiMin="-166" iRefHit="44" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="5" iPhiMax="-54" iPhiMin="-166" iRefHit="45" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="59" iPhiMin="-53" iRefHit="46" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="5" iPhiMax="59" iPhiMin="-53" iRefHit="47" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="59" iPhiMin="-53" iRefHit="48" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="7" iPhiMax="59" iPhiMin="-53" iRefHit="49" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="172" iPhiMin="60" iRefHit="50" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="7" iPhiMax="172" iPhiMin="60" iRefHit="51" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="172" iPhiMin="60" iRefHit="52" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="9" iPhiMax="172" iPhiMin="60" iRefHit="53" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="285" iPhiMin="173" iRefHit="54" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="9" iPhiMax="285" iPhiMin="173" iRefHit="55" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="10" iPhiMax="285" iPhiMin="173" iRefHit="56" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="11" iPhiMax="285" iPhiMin="173" iRefHit="57" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-281" iPhiMin="-393" iRefHit="58" iRefLayer="4" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-281" iPhiMin="-393" iRefHit="59" iRefLayer="4" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-168" iPhiMin="-280" iRefHit="60" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-168" iPhiMin="-280" iRefHit="61" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-168" iPhiMin="-280" iRefHit="62" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="3" iPhiMax="-168" iPhiMin="-280" iRefHit="63" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-55" iPhiMin="-167" iRefHit="64" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="3" iPhiMax="-55" iPhiMin="-167" iRefHit="65" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="-55" iPhiMin="-167" iRefHit="66" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="5" iPhiMax="-55" iPhiMin="-167" iRefHit="67" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="58" iPhiMin="-54" iRefHit="68" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="5" iPhiMax="58" iPhiMin="-54" iRefHit="69" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="58" iPhiMin="-54" iRefHit="70" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="7" iPhiMax="58" iPhiMin="-54" iRefHit="71" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="171" iPhiMin="59" iRefHit="72" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="7" iPhiMax="171" iPhiMin="59" iRefHit="73" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="171" iPhiMin="59" iRefHit="74" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="9" iPhiMax="171" iPhiMin="59" iRefHit="75" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="284" iPhiMin="172" iRefHit="76" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="9" iPhiMax="284" iPhiMin="172" iRefHit="77" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="10" iPhiMax="284" iPhiMin="172" iRefHit="78" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="11" iPhiMax="284" iPhiMin="172" iRefHit="79" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-322" iPhiMin="-434" iRefHit="80" iRefLayer="5" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-322" iPhiMin="-434" iRefHit="81" iRefLayer="5" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-209" iPhiMin="-321" iRefHit="82" iRefLayer="5" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-209" iPhiMin="-321" iRefHit="83" iRefLayer="5" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-96" iPhiMin="-208" iRefHit="84" iRefLayer="5" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-96" iPhiMin="-208" iRefHit="85" iRefLayer="5" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="17" iPhiMin="-95" iRefHit="86" iRefLayer="5" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="17" iPhiMin="-95" iRefHit="87" iRefLayer="5" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="130" iPhiMin="18" iRefHit="88" iRefLayer="5" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="130" iPhiMin="18" iRefHit="89" iRefLayer="5" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="243" iPhiMin="131" iRefHit="90" iRefLayer="5" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="243" iPhiMin="131" iRefHit="91" iRefLayer="5" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-321" iPhiMin="-433" iRefHit="92" iRefLayer="6" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-321" iPhiMin="-433" iRefHit="93" iRefLayer="6" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-208" iPhiMin="-320" iRefHit="94" iRefLayer="6" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-208" iPhiMin="-320" iRefHit="95" iRefLayer="6" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-95" iPhiMin="-207" iRefHit="96" iRefLayer="6" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-95" iPhiMin="-207" iRefHit="97" iRefLayer="6" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="18" iPhiMin="-94" iRefHit="98" iRefLayer="6" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="18" iPhiMin="-94" iRefHit="99" iRefLayer="6" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="131" iPhiMin="19" iRefHit="100" iRefLayer="6" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="131" iPhiMin="19" iRefHit="101" iRefLayer="6" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="244" iPhiMin="132" iRefHit="102" iRefLayer="6" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="244" iPhiMin="132" iRefHit="103" iRefLayer="6" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-359" iPhiMin="-471" iRefHit="104" iRefLayer="7" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-359" iPhiMin="-471" iRefHit="105" iRefLayer="7" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-246" iPhiMin="-358" iRefHit="106" iRefLayer="7" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-246" iPhiMin="-358" iRefHit="107" iRefLayer="7" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-133" iPhiMin="-245" iRefHit="108" iRefLayer="7" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-133" iPhiMin="-245" iRefHit="109" iRefLayer="7" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="-20" iPhiMin="-132" iRefHit="110" iRefLayer="7" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="-20" iPhiMin="-132" iRefHit="111" iRefLayer="7" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="93" iPhiMin="-19" iRefHit="112" iRefLayer="7" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="93" iPhiMin="-19" iRefHit="113" iRefLayer="7" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="206" iPhiMin="94" iRefHit="114" iRefLayer="7" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="206" iPhiMin="94" iRefHit="115" iRefLayer="7" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="116" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="117" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="118" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="119" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="120" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="121" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="122" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="123" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="124" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="125" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="126" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="127" iRefLayer="0" iRegion="0"/>
     <LogicRegion iRegion="0">
       <Layer iFirstInput="0" iLayer="0" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="4"/>
@@ -74,22 +189,6 @@
       <Layer iFirstInput="0" iLayer="16" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="17" nInputs="4"/>
     </LogicRegion>
-    <RefHit iInput="0" iPhiMax="-198" iPhiMin="-310" iRefHit="13" iRefLayer="0" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-286" iPhiMin="-398" iRefHit="14" iRefLayer="1" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-238" iPhiMin="-350" iRefHit="15" iRefLayer="2" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-167" iPhiMin="-279" iRefHit="16" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="2" iPhiMax="-167" iPhiMin="-279" iRefHit="17" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="3" iPhiMax="-167" iPhiMin="-279" iRefHit="18" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-168" iPhiMin="-280" iRefHit="19" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-168" iPhiMin="-280" iRefHit="20" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="2" iPhiMax="-168" iPhiMin="-280" iRefHit="21" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="3" iPhiMax="-168" iPhiMin="-280" iRefHit="22" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-209" iPhiMin="-321" iRefHit="23" iRefLayer="5" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-209" iPhiMin="-321" iRefHit="24" iRefLayer="5" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-208" iPhiMin="-320" iRefHit="25" iRefLayer="6" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-208" iPhiMin="-320" iRefHit="26" iRefLayer="6" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-246" iPhiMin="-358" iRefHit="27" iRefLayer="7" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-246" iPhiMin="-358" iRefHit="28" iRefLayer="7" iRegion="1"/>
     <LogicRegion iRegion="1">
       <Layer iFirstInput="0" iLayer="0" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="4"/>
@@ -110,24 +209,6 @@
       <Layer iFirstInput="0" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="0" iPhiMax="-85" iPhiMin="-197" iRefHit="29" iRefLayer="0" iRegion="2"/>
-    <RefHit iInput="2" iPhiMax="-85" iPhiMin="-197" iRefHit="30" iRefLayer="0" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-173" iPhiMin="-285" iRefHit="31" iRefLayer="1" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-125" iPhiMin="-237" iRefHit="32" iRefLayer="2" iRegion="2"/>
-    <RefHit iInput="2" iPhiMax="-54" iPhiMin="-166" iRefHit="33" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="3" iPhiMax="-54" iPhiMin="-166" iRefHit="34" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="4" iPhiMax="-54" iPhiMin="-166" iRefHit="35" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="5" iPhiMax="-54" iPhiMin="-166" iRefHit="36" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="2" iPhiMax="-55" iPhiMin="-167" iRefHit="37" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="3" iPhiMax="-55" iPhiMin="-167" iRefHit="38" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="4" iPhiMax="-55" iPhiMin="-167" iRefHit="39" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="5" iPhiMax="-55" iPhiMin="-167" iRefHit="40" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-96" iPhiMin="-208" iRefHit="41" iRefLayer="5" iRegion="2"/>
-    <RefHit iInput="1" iPhiMax="-96" iPhiMin="-208" iRefHit="42" iRefLayer="5" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-95" iPhiMin="-207" iRefHit="43" iRefLayer="6" iRegion="2"/>
-    <RefHit iInput="1" iPhiMax="-95" iPhiMin="-207" iRefHit="44" iRefLayer="6" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-133" iPhiMin="-245" iRefHit="45" iRefLayer="7" iRegion="2"/>
-    <RefHit iInput="1" iPhiMax="-133" iPhiMin="-245" iRefHit="46" iRefLayer="7" iRegion="2"/>
     <LogicRegion iRegion="2">
       <Layer iFirstInput="0" iLayer="0" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="4"/>
@@ -148,23 +229,6 @@
       <Layer iFirstInput="2" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="2" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="2" iPhiMax="28" iPhiMin="-84" iRefHit="47" iRefLayer="0" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="-60" iPhiMin="-172" iRefHit="48" iRefLayer="1" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="-12" iPhiMin="-124" iRefHit="49" iRefLayer="2" iRegion="3"/>
-    <RefHit iInput="4" iPhiMax="59" iPhiMin="-53" iRefHit="50" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="5" iPhiMax="59" iPhiMin="-53" iRefHit="51" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="6" iPhiMax="59" iPhiMin="-53" iRefHit="52" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="7" iPhiMax="59" iPhiMin="-53" iRefHit="53" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="4" iPhiMax="58" iPhiMin="-54" iRefHit="54" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="5" iPhiMax="58" iPhiMin="-54" iRefHit="55" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="6" iPhiMax="58" iPhiMin="-54" iRefHit="56" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="7" iPhiMax="58" iPhiMin="-54" iRefHit="57" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="17" iPhiMin="-95" iRefHit="58" iRefLayer="5" iRegion="3"/>
-    <RefHit iInput="3" iPhiMax="17" iPhiMin="-95" iRefHit="59" iRefLayer="5" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="18" iPhiMin="-94" iRefHit="60" iRefLayer="6" iRegion="3"/>
-    <RefHit iInput="3" iPhiMax="18" iPhiMin="-94" iRefHit="61" iRefLayer="6" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="-20" iPhiMin="-132" iRefHit="62" iRefLayer="7" iRegion="3"/>
-    <RefHit iInput="3" iPhiMax="-20" iPhiMin="-132" iRefHit="63" iRefLayer="7" iRegion="3"/>
     <LogicRegion iRegion="3">
       <Layer iFirstInput="0" iLayer="0" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="6"/>
@@ -185,23 +249,6 @@
       <Layer iFirstInput="4" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="4" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="2" iPhiMax="141" iPhiMin="29" iRefHit="64" iRefLayer="0" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="53" iPhiMin="-59" iRefHit="65" iRefLayer="1" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="101" iPhiMin="-11" iRefHit="66" iRefLayer="2" iRegion="4"/>
-    <RefHit iInput="6" iPhiMax="172" iPhiMin="60" iRefHit="67" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="7" iPhiMax="172" iPhiMin="60" iRefHit="68" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="8" iPhiMax="172" iPhiMin="60" iRefHit="69" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="9" iPhiMax="172" iPhiMin="60" iRefHit="70" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="6" iPhiMax="171" iPhiMin="59" iRefHit="71" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="7" iPhiMax="171" iPhiMin="59" iRefHit="72" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="8" iPhiMax="171" iPhiMin="59" iRefHit="73" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="9" iPhiMax="171" iPhiMin="59" iRefHit="74" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="130" iPhiMin="18" iRefHit="75" iRefLayer="5" iRegion="4"/>
-    <RefHit iInput="3" iPhiMax="130" iPhiMin="18" iRefHit="76" iRefLayer="5" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="131" iPhiMin="19" iRefHit="77" iRefLayer="6" iRegion="4"/>
-    <RefHit iInput="3" iPhiMax="131" iPhiMin="19" iRefHit="78" iRefLayer="6" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="93" iPhiMin="-19" iRefHit="79" iRefLayer="7" iRegion="4"/>
-    <RefHit iInput="3" iPhiMax="93" iPhiMin="-19" iRefHit="80" iRefLayer="7" iRegion="4"/>
     <LogicRegion iRegion="4">
       <Layer iFirstInput="0" iLayer="0" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="6"/>
@@ -222,53 +269,6 @@
       <Layer iFirstInput="6" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="6" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="2" iPhiMax="254" iPhiMin="142" iRefHit="81" iRefLayer="0" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="166" iPhiMin="54" iRefHit="82" iRefLayer="1" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="214" iPhiMin="102" iRefHit="83" iRefLayer="2" iRegion="5"/>
-    <RefHit iInput="8" iPhiMax="285" iPhiMin="173" iRefHit="84" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="9" iPhiMax="285" iPhiMin="173" iRefHit="85" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="10" iPhiMax="285" iPhiMin="173" iRefHit="86" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="11" iPhiMax="285" iPhiMin="173" iRefHit="87" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="8" iPhiMax="284" iPhiMin="172" iRefHit="88" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="9" iPhiMax="284" iPhiMin="172" iRefHit="89" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="10" iPhiMax="284" iPhiMin="172" iRefHit="90" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="11" iPhiMax="284" iPhiMin="172" iRefHit="91" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="243" iPhiMin="131" iRefHit="92" iRefLayer="5" iRegion="5"/>
-    <RefHit iInput="3" iPhiMax="243" iPhiMin="131" iRefHit="93" iRefLayer="5" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="244" iPhiMin="132" iRefHit="94" iRefLayer="6" iRegion="5"/>
-    <RefHit iInput="3" iPhiMax="244" iPhiMin="132" iRefHit="95" iRefLayer="6" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="206" iPhiMin="94" iRefHit="96" iRefLayer="7" iRegion="5"/>
-    <RefHit iInput="3" iPhiMax="206" iPhiMin="94" iRefHit="97" iRefLayer="7" iRegion="5"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="98" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="99" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="100" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="101" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="102" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="103" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="104" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="105" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="106" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="107" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="108" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="109" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="110" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="111" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="112" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="113" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="114" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="115" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="116" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="117" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="118" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="119" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="120" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="121" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="122" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="123" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="124" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="125" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="126" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="127" iRefLayer="0" iRegion="0"/>
     <LogicRegion iRegion="5">
       <Layer iFirstInput="0" iLayer="0" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="6"/>
@@ -301,18 +301,133 @@
     <RefLayer iGlobalPhiStart="583" iRefLayer="6"/>
     <RefLayer iGlobalPhiStart="547" iRefLayer="7"/>
     <RefHit iInput="0" iPhiMax="-313" iPhiMin="-425" iRefHit="0" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-399" iPhiMin="-511" iRefHit="1" iRefLayer="1" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-353" iPhiMin="-465" iRefHit="2" iRefLayer="2" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-281" iPhiMin="-393" iRefHit="3" iRefLayer="3" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-281" iPhiMin="-393" iRefHit="4" iRefLayer="3" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-282" iPhiMin="-394" iRefHit="5" iRefLayer="4" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-282" iPhiMin="-394" iRefHit="6" iRefLayer="4" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-322" iPhiMin="-434" iRefHit="7" iRefLayer="5" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-322" iPhiMin="-434" iRefHit="8" iRefLayer="5" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-321" iPhiMin="-433" iRefHit="9" iRefLayer="6" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-321" iPhiMin="-433" iRefHit="10" iRefLayer="6" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-357" iPhiMin="-469" iRefHit="11" iRefLayer="7" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-357" iPhiMin="-469" iRefHit="12" iRefLayer="7" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-313" iPhiMin="-425" iRefHit="1" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-200" iPhiMin="-312" iRefHit="2" iRefLayer="0" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-200" iPhiMin="-312" iRefHit="3" iRefLayer="0" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-87" iPhiMin="-199" iRefHit="4" iRefLayer="0" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-87" iPhiMin="-199" iRefHit="5" iRefLayer="0" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="26" iPhiMin="-86" iRefHit="6" iRefLayer="0" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="26" iPhiMin="-86" iRefHit="7" iRefLayer="0" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="139" iPhiMin="27" iRefHit="8" iRefLayer="0" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="139" iPhiMin="27" iRefHit="9" iRefLayer="0" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="252" iPhiMin="140" iRefHit="10" iRefLayer="0" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="252" iPhiMin="140" iRefHit="11" iRefLayer="0" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-399" iPhiMin="-511" iRefHit="12" iRefLayer="1" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-399" iPhiMin="-511" iRefHit="13" iRefLayer="1" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-286" iPhiMin="-398" iRefHit="14" iRefLayer="1" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-286" iPhiMin="-398" iRefHit="15" iRefLayer="1" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-173" iPhiMin="-285" iRefHit="16" iRefLayer="1" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-173" iPhiMin="-285" iRefHit="17" iRefLayer="1" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="-60" iPhiMin="-172" iRefHit="18" iRefLayer="1" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="-60" iPhiMin="-172" iRefHit="19" iRefLayer="1" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="53" iPhiMin="-59" iRefHit="20" iRefLayer="1" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="53" iPhiMin="-59" iRefHit="21" iRefLayer="1" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="166" iPhiMin="54" iRefHit="22" iRefLayer="1" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="166" iPhiMin="54" iRefHit="23" iRefLayer="1" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-353" iPhiMin="-465" iRefHit="24" iRefLayer="2" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-353" iPhiMin="-465" iRefHit="25" iRefLayer="2" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-240" iPhiMin="-352" iRefHit="26" iRefLayer="2" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-240" iPhiMin="-352" iRefHit="27" iRefLayer="2" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-127" iPhiMin="-239" iRefHit="28" iRefLayer="2" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-127" iPhiMin="-239" iRefHit="29" iRefLayer="2" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="-14" iPhiMin="-126" iRefHit="30" iRefLayer="2" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="-14" iPhiMin="-126" iRefHit="31" iRefLayer="2" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="99" iPhiMin="-13" iRefHit="32" iRefLayer="2" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="99" iPhiMin="-13" iRefHit="33" iRefLayer="2" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="212" iPhiMin="100" iRefHit="34" iRefLayer="2" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="212" iPhiMin="100" iRefHit="35" iRefLayer="2" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-281" iPhiMin="-393" iRefHit="36" iRefLayer="3" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-281" iPhiMin="-393" iRefHit="37" iRefLayer="3" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-168" iPhiMin="-280" iRefHit="38" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-168" iPhiMin="-280" iRefHit="39" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-168" iPhiMin="-280" iRefHit="40" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="3" iPhiMax="-168" iPhiMin="-280" iRefHit="41" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-55" iPhiMin="-167" iRefHit="42" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="3" iPhiMax="-55" iPhiMin="-167" iRefHit="43" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="-55" iPhiMin="-167" iRefHit="44" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="5" iPhiMax="-55" iPhiMin="-167" iRefHit="45" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="58" iPhiMin="-54" iRefHit="46" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="5" iPhiMax="58" iPhiMin="-54" iRefHit="47" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="58" iPhiMin="-54" iRefHit="48" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="7" iPhiMax="58" iPhiMin="-54" iRefHit="49" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="171" iPhiMin="59" iRefHit="50" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="7" iPhiMax="171" iPhiMin="59" iRefHit="51" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="171" iPhiMin="59" iRefHit="52" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="9" iPhiMax="171" iPhiMin="59" iRefHit="53" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="284" iPhiMin="172" iRefHit="54" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="9" iPhiMax="284" iPhiMin="172" iRefHit="55" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="10" iPhiMax="284" iPhiMin="172" iRefHit="56" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="11" iPhiMax="284" iPhiMin="172" iRefHit="57" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-282" iPhiMin="-394" iRefHit="58" iRefLayer="4" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-282" iPhiMin="-394" iRefHit="59" iRefLayer="4" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-169" iPhiMin="-281" iRefHit="60" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-169" iPhiMin="-281" iRefHit="61" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-169" iPhiMin="-281" iRefHit="62" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="3" iPhiMax="-169" iPhiMin="-281" iRefHit="63" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-56" iPhiMin="-168" iRefHit="64" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="3" iPhiMax="-56" iPhiMin="-168" iRefHit="65" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="-56" iPhiMin="-168" iRefHit="66" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="5" iPhiMax="-56" iPhiMin="-168" iRefHit="67" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="57" iPhiMin="-55" iRefHit="68" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="5" iPhiMax="57" iPhiMin="-55" iRefHit="69" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="57" iPhiMin="-55" iRefHit="70" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="7" iPhiMax="57" iPhiMin="-55" iRefHit="71" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="170" iPhiMin="58" iRefHit="72" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="7" iPhiMax="170" iPhiMin="58" iRefHit="73" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="170" iPhiMin="58" iRefHit="74" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="9" iPhiMax="170" iPhiMin="58" iRefHit="75" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="283" iPhiMin="171" iRefHit="76" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="9" iPhiMax="283" iPhiMin="171" iRefHit="77" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="10" iPhiMax="283" iPhiMin="171" iRefHit="78" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="11" iPhiMax="283" iPhiMin="171" iRefHit="79" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-322" iPhiMin="-434" iRefHit="80" iRefLayer="5" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-322" iPhiMin="-434" iRefHit="81" iRefLayer="5" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-209" iPhiMin="-321" iRefHit="82" iRefLayer="5" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-209" iPhiMin="-321" iRefHit="83" iRefLayer="5" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-96" iPhiMin="-208" iRefHit="84" iRefLayer="5" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-96" iPhiMin="-208" iRefHit="85" iRefLayer="5" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="17" iPhiMin="-95" iRefHit="86" iRefLayer="5" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="17" iPhiMin="-95" iRefHit="87" iRefLayer="5" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="130" iPhiMin="18" iRefHit="88" iRefLayer="5" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="130" iPhiMin="18" iRefHit="89" iRefLayer="5" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="243" iPhiMin="131" iRefHit="90" iRefLayer="5" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="243" iPhiMin="131" iRefHit="91" iRefLayer="5" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-321" iPhiMin="-433" iRefHit="92" iRefLayer="6" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-321" iPhiMin="-433" iRefHit="93" iRefLayer="6" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-208" iPhiMin="-320" iRefHit="94" iRefLayer="6" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-208" iPhiMin="-320" iRefHit="95" iRefLayer="6" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-95" iPhiMin="-207" iRefHit="96" iRefLayer="6" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-95" iPhiMin="-207" iRefHit="97" iRefLayer="6" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="18" iPhiMin="-94" iRefHit="98" iRefLayer="6" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="18" iPhiMin="-94" iRefHit="99" iRefLayer="6" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="131" iPhiMin="19" iRefHit="100" iRefLayer="6" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="131" iPhiMin="19" iRefHit="101" iRefLayer="6" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="244" iPhiMin="132" iRefHit="102" iRefLayer="6" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="244" iPhiMin="132" iRefHit="103" iRefLayer="6" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-357" iPhiMin="-469" iRefHit="104" iRefLayer="7" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-357" iPhiMin="-469" iRefHit="105" iRefLayer="7" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-244" iPhiMin="-356" iRefHit="106" iRefLayer="7" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-244" iPhiMin="-356" iRefHit="107" iRefLayer="7" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-131" iPhiMin="-243" iRefHit="108" iRefLayer="7" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-131" iPhiMin="-243" iRefHit="109" iRefLayer="7" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="-18" iPhiMin="-130" iRefHit="110" iRefLayer="7" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="-18" iPhiMin="-130" iRefHit="111" iRefLayer="7" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="95" iPhiMin="-17" iRefHit="112" iRefLayer="7" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="95" iPhiMin="-17" iRefHit="113" iRefLayer="7" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="208" iPhiMin="96" iRefHit="114" iRefLayer="7" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="208" iPhiMin="96" iRefHit="115" iRefLayer="7" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="116" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="117" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="118" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="119" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="120" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="121" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="122" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="123" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="124" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="125" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="126" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="127" iRefLayer="0" iRegion="0"/>
     <LogicRegion iRegion="0">
       <Layer iFirstInput="0" iLayer="0" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="4"/>
@@ -333,23 +448,6 @@
       <Layer iFirstInput="0" iLayer="16" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="17" nInputs="4"/>
     </LogicRegion>
-    <RefHit iInput="0" iPhiMax="-200" iPhiMin="-312" iRefHit="13" iRefLayer="0" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-286" iPhiMin="-398" iRefHit="14" iRefLayer="1" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-240" iPhiMin="-352" iRefHit="15" iRefLayer="2" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-168" iPhiMin="-280" iRefHit="16" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-168" iPhiMin="-280" iRefHit="17" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="2" iPhiMax="-168" iPhiMin="-280" iRefHit="18" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="3" iPhiMax="-168" iPhiMin="-280" iRefHit="19" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-169" iPhiMin="-281" iRefHit="20" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-169" iPhiMin="-281" iRefHit="21" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="2" iPhiMax="-169" iPhiMin="-281" iRefHit="22" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="3" iPhiMax="-169" iPhiMin="-281" iRefHit="23" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-209" iPhiMin="-321" iRefHit="24" iRefLayer="5" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-209" iPhiMin="-321" iRefHit="25" iRefLayer="5" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-208" iPhiMin="-320" iRefHit="26" iRefLayer="6" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-208" iPhiMin="-320" iRefHit="27" iRefLayer="6" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-244" iPhiMin="-356" iRefHit="28" iRefLayer="7" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-244" iPhiMin="-356" iRefHit="29" iRefLayer="7" iRegion="1"/>
     <LogicRegion iRegion="1">
       <Layer iFirstInput="0" iLayer="0" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="4"/>
@@ -370,23 +468,6 @@
       <Layer iFirstInput="0" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="0" iPhiMax="-87" iPhiMin="-199" iRefHit="30" iRefLayer="0" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-173" iPhiMin="-285" iRefHit="31" iRefLayer="1" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-127" iPhiMin="-239" iRefHit="32" iRefLayer="2" iRegion="2"/>
-    <RefHit iInput="2" iPhiMax="-55" iPhiMin="-167" iRefHit="33" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="3" iPhiMax="-55" iPhiMin="-167" iRefHit="34" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="4" iPhiMax="-55" iPhiMin="-167" iRefHit="35" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="5" iPhiMax="-55" iPhiMin="-167" iRefHit="36" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="2" iPhiMax="-56" iPhiMin="-168" iRefHit="37" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="3" iPhiMax="-56" iPhiMin="-168" iRefHit="38" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="4" iPhiMax="-56" iPhiMin="-168" iRefHit="39" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="5" iPhiMax="-56" iPhiMin="-168" iRefHit="40" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-96" iPhiMin="-208" iRefHit="41" iRefLayer="5" iRegion="2"/>
-    <RefHit iInput="1" iPhiMax="-96" iPhiMin="-208" iRefHit="42" iRefLayer="5" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-95" iPhiMin="-207" iRefHit="43" iRefLayer="6" iRegion="2"/>
-    <RefHit iInput="1" iPhiMax="-95" iPhiMin="-207" iRefHit="44" iRefLayer="6" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-131" iPhiMin="-243" iRefHit="45" iRefLayer="7" iRegion="2"/>
-    <RefHit iInput="1" iPhiMax="-131" iPhiMin="-243" iRefHit="46" iRefLayer="7" iRegion="2"/>
     <LogicRegion iRegion="2">
       <Layer iFirstInput="0" iLayer="0" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="4"/>
@@ -407,22 +488,6 @@
       <Layer iFirstInput="2" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="2" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="2" iPhiMax="26" iPhiMin="-86" iRefHit="47" iRefLayer="0" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="-60" iPhiMin="-172" iRefHit="48" iRefLayer="1" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="-14" iPhiMin="-126" iRefHit="49" iRefLayer="2" iRegion="3"/>
-    <RefHit iInput="4" iPhiMax="58" iPhiMin="-54" iRefHit="50" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="6" iPhiMax="58" iPhiMin="-54" iRefHit="51" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="7" iPhiMax="58" iPhiMin="-54" iRefHit="52" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="4" iPhiMax="57" iPhiMin="-55" iRefHit="53" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="5" iPhiMax="57" iPhiMin="-55" iRefHit="54" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="6" iPhiMax="57" iPhiMin="-55" iRefHit="55" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="7" iPhiMax="57" iPhiMin="-55" iRefHit="56" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="17" iPhiMin="-95" iRefHit="57" iRefLayer="5" iRegion="3"/>
-    <RefHit iInput="3" iPhiMax="17" iPhiMin="-95" iRefHit="58" iRefLayer="5" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="18" iPhiMin="-94" iRefHit="59" iRefLayer="6" iRegion="3"/>
-    <RefHit iInput="3" iPhiMax="18" iPhiMin="-94" iRefHit="60" iRefLayer="6" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="-18" iPhiMin="-130" iRefHit="61" iRefLayer="7" iRegion="3"/>
-    <RefHit iInput="3" iPhiMax="-18" iPhiMin="-130" iRefHit="62" iRefLayer="7" iRegion="3"/>
     <LogicRegion iRegion="3">
       <Layer iFirstInput="0" iLayer="0" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="6"/>
@@ -436,30 +501,13 @@
       <Layer iFirstInput="4" iLayer="9" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="10" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="11" nInputs="6"/>
-      <Layer iFirstInput="2" iLayer="12" nInputs="6"/>
+      <Layer iFirstInput="0" iLayer="12" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="13" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="14" nInputs="6"/>
       <Layer iFirstInput="4" iLayer="15" nInputs="6"/>
       <Layer iFirstInput="4" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="4" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="2" iPhiMax="139" iPhiMin="27" iRefHit="63" iRefLayer="0" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="53" iPhiMin="-59" iRefHit="64" iRefLayer="1" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="99" iPhiMin="-13" iRefHit="65" iRefLayer="2" iRegion="4"/>
-    <RefHit iInput="6" iPhiMax="171" iPhiMin="59" iRefHit="66" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="7" iPhiMax="171" iPhiMin="59" iRefHit="67" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="8" iPhiMax="171" iPhiMin="59" iRefHit="68" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="9" iPhiMax="171" iPhiMin="59" iRefHit="69" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="6" iPhiMax="170" iPhiMin="58" iRefHit="70" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="7" iPhiMax="170" iPhiMin="58" iRefHit="71" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="8" iPhiMax="170" iPhiMin="58" iRefHit="72" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="9" iPhiMax="170" iPhiMin="58" iRefHit="73" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="130" iPhiMin="18" iRefHit="74" iRefLayer="5" iRegion="4"/>
-    <RefHit iInput="3" iPhiMax="130" iPhiMin="18" iRefHit="75" iRefLayer="5" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="131" iPhiMin="19" iRefHit="76" iRefLayer="6" iRegion="4"/>
-    <RefHit iInput="3" iPhiMax="131" iPhiMin="19" iRefHit="77" iRefLayer="6" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="95" iPhiMin="-17" iRefHit="78" iRefLayer="7" iRegion="4"/>
-    <RefHit iInput="3" iPhiMax="95" iPhiMin="-17" iRefHit="79" iRefLayer="7" iRegion="4"/>
     <LogicRegion iRegion="4">
       <Layer iFirstInput="0" iLayer="0" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="6"/>
@@ -480,54 +528,6 @@
       <Layer iFirstInput="6" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="6" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="2" iPhiMax="252" iPhiMin="140" iRefHit="80" iRefLayer="0" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="166" iPhiMin="54" iRefHit="81" iRefLayer="1" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="212" iPhiMin="100" iRefHit="82" iRefLayer="2" iRegion="5"/>
-    <RefHit iInput="8" iPhiMax="284" iPhiMin="172" iRefHit="83" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="10" iPhiMax="284" iPhiMin="172" iRefHit="84" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="11" iPhiMax="284" iPhiMin="172" iRefHit="85" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="8" iPhiMax="283" iPhiMin="171" iRefHit="86" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="9" iPhiMax="283" iPhiMin="171" iRefHit="87" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="10" iPhiMax="283" iPhiMin="171" iRefHit="88" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="11" iPhiMax="283" iPhiMin="171" iRefHit="89" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="243" iPhiMin="131" iRefHit="90" iRefLayer="5" iRegion="5"/>
-    <RefHit iInput="3" iPhiMax="243" iPhiMin="131" iRefHit="91" iRefLayer="5" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="244" iPhiMin="132" iRefHit="92" iRefLayer="6" iRegion="5"/>
-    <RefHit iInput="3" iPhiMax="244" iPhiMin="132" iRefHit="93" iRefLayer="6" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="208" iPhiMin="96" iRefHit="94" iRefLayer="7" iRegion="5"/>
-    <RefHit iInput="3" iPhiMax="208" iPhiMin="96" iRefHit="95" iRefLayer="7" iRegion="5"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="96" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="97" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="98" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="99" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="100" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="101" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="102" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="103" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="104" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="105" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="106" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="107" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="108" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="109" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="110" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="111" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="112" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="113" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="114" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="115" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="116" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="117" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="118" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="119" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="120" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="121" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="122" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="123" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="124" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="125" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="126" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="127" iRefLayer="0" iRegion="0"/>
     <LogicRegion iRegion="5">
       <Layer iFirstInput="0" iLayer="0" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="6"/>
@@ -560,18 +560,133 @@
     <RefLayer iGlobalPhiStart="1266" iRefLayer="6"/>
     <RefLayer iGlobalPhiStart="1227" iRefLayer="7"/>
     <RefHit iInput="0" iPhiMax="-313" iPhiMin="-425" iRefHit="0" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-399" iPhiMin="-511" iRefHit="1" iRefLayer="1" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-338" iPhiMin="-450" iRefHit="2" iRefLayer="2" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-279" iPhiMin="-391" iRefHit="3" iRefLayer="3" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-279" iPhiMin="-391" iRefHit="4" iRefLayer="3" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-280" iPhiMin="-392" iRefHit="5" iRefLayer="4" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-280" iPhiMin="-392" iRefHit="6" iRefLayer="4" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-321" iPhiMin="-433" iRefHit="7" iRefLayer="5" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-321" iPhiMin="-433" iRefHit="8" iRefLayer="5" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-319" iPhiMin="-431" iRefHit="9" iRefLayer="6" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-319" iPhiMin="-431" iRefHit="10" iRefLayer="6" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-358" iPhiMin="-470" iRefHit="11" iRefLayer="7" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-358" iPhiMin="-470" iRefHit="12" iRefLayer="7" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-313" iPhiMin="-425" iRefHit="1" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-200" iPhiMin="-312" iRefHit="2" iRefLayer="0" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-200" iPhiMin="-312" iRefHit="3" iRefLayer="0" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-87" iPhiMin="-199" iRefHit="4" iRefLayer="0" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-87" iPhiMin="-199" iRefHit="5" iRefLayer="0" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="26" iPhiMin="-86" iRefHit="6" iRefLayer="0" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="26" iPhiMin="-86" iRefHit="7" iRefLayer="0" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="139" iPhiMin="27" iRefHit="8" iRefLayer="0" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="139" iPhiMin="27" iRefHit="9" iRefLayer="0" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="252" iPhiMin="140" iRefHit="10" iRefLayer="0" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="252" iPhiMin="140" iRefHit="11" iRefLayer="0" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-399" iPhiMin="-511" iRefHit="12" iRefLayer="1" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-399" iPhiMin="-511" iRefHit="13" iRefLayer="1" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-286" iPhiMin="-398" iRefHit="14" iRefLayer="1" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-286" iPhiMin="-398" iRefHit="15" iRefLayer="1" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-173" iPhiMin="-285" iRefHit="16" iRefLayer="1" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-173" iPhiMin="-285" iRefHit="17" iRefLayer="1" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="-60" iPhiMin="-172" iRefHit="18" iRefLayer="1" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="-60" iPhiMin="-172" iRefHit="19" iRefLayer="1" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="53" iPhiMin="-59" iRefHit="20" iRefLayer="1" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="53" iPhiMin="-59" iRefHit="21" iRefLayer="1" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="166" iPhiMin="54" iRefHit="22" iRefLayer="1" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="166" iPhiMin="54" iRefHit="23" iRefLayer="1" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-338" iPhiMin="-450" iRefHit="24" iRefLayer="2" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-338" iPhiMin="-450" iRefHit="25" iRefLayer="2" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-225" iPhiMin="-337" iRefHit="26" iRefLayer="2" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-225" iPhiMin="-337" iRefHit="27" iRefLayer="2" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-112" iPhiMin="-224" iRefHit="28" iRefLayer="2" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-112" iPhiMin="-224" iRefHit="29" iRefLayer="2" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="-112" iPhiMin="-224" iRefHit="30" iRefLayer="2" iRegion="2"/>
+    <RefHit iInput="3" iPhiMax="-112" iPhiMin="-224" iRefHit="31" iRefLayer="2" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="1" iPhiMin="-111" iRefHit="32" iRefLayer="2" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="1" iPhiMin="-111" iRefHit="33" iRefLayer="2" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="114" iPhiMin="2" iRefHit="34" iRefLayer="2" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="114" iPhiMin="2" iRefHit="35" iRefLayer="2" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="227" iPhiMin="115" iRefHit="36" iRefLayer="2" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="227" iPhiMin="115" iRefHit="37" iRefLayer="2" iRegion="5"/>
+    <RefHit iInput="4" iPhiMax="227" iPhiMin="115" iRefHit="38" iRefLayer="2" iRegion="5"/>
+    <RefHit iInput="5" iPhiMax="227" iPhiMin="115" iRefHit="39" iRefLayer="2" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-279" iPhiMin="-391" iRefHit="40" iRefLayer="3" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-279" iPhiMin="-391" iRefHit="41" iRefLayer="3" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-166" iPhiMin="-278" iRefHit="42" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-166" iPhiMin="-278" iRefHit="43" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-166" iPhiMin="-278" iRefHit="44" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="3" iPhiMax="-166" iPhiMin="-278" iRefHit="45" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-53" iPhiMin="-165" iRefHit="46" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="3" iPhiMax="-53" iPhiMin="-165" iRefHit="47" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="-53" iPhiMin="-165" iRefHit="48" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="5" iPhiMax="-53" iPhiMin="-165" iRefHit="49" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="60" iPhiMin="-52" iRefHit="50" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="5" iPhiMax="60" iPhiMin="-52" iRefHit="51" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="60" iPhiMin="-52" iRefHit="52" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="7" iPhiMax="60" iPhiMin="-52" iRefHit="53" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="173" iPhiMin="61" iRefHit="54" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="7" iPhiMax="173" iPhiMin="61" iRefHit="55" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="173" iPhiMin="61" iRefHit="56" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="9" iPhiMax="173" iPhiMin="61" iRefHit="57" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="286" iPhiMin="174" iRefHit="58" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="9" iPhiMax="286" iPhiMin="174" iRefHit="59" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="10" iPhiMax="286" iPhiMin="174" iRefHit="60" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="11" iPhiMax="286" iPhiMin="174" iRefHit="61" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-280" iPhiMin="-392" iRefHit="62" iRefLayer="4" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-280" iPhiMin="-392" iRefHit="63" iRefLayer="4" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-167" iPhiMin="-279" iRefHit="64" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-167" iPhiMin="-279" iRefHit="65" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-167" iPhiMin="-279" iRefHit="66" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="3" iPhiMax="-167" iPhiMin="-279" iRefHit="67" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-54" iPhiMin="-166" iRefHit="68" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="3" iPhiMax="-54" iPhiMin="-166" iRefHit="69" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="-54" iPhiMin="-166" iRefHit="70" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="5" iPhiMax="-54" iPhiMin="-166" iRefHit="71" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="59" iPhiMin="-53" iRefHit="72" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="5" iPhiMax="59" iPhiMin="-53" iRefHit="73" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="59" iPhiMin="-53" iRefHit="74" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="7" iPhiMax="59" iPhiMin="-53" iRefHit="75" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="172" iPhiMin="60" iRefHit="76" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="7" iPhiMax="172" iPhiMin="60" iRefHit="77" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="172" iPhiMin="60" iRefHit="78" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="9" iPhiMax="172" iPhiMin="60" iRefHit="79" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="285" iPhiMin="173" iRefHit="80" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="9" iPhiMax="285" iPhiMin="173" iRefHit="81" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="10" iPhiMax="285" iPhiMin="173" iRefHit="82" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="11" iPhiMax="285" iPhiMin="173" iRefHit="83" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-321" iPhiMin="-433" iRefHit="84" iRefLayer="5" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-321" iPhiMin="-433" iRefHit="85" iRefLayer="5" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-208" iPhiMin="-320" iRefHit="86" iRefLayer="5" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-208" iPhiMin="-320" iRefHit="87" iRefLayer="5" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-95" iPhiMin="-207" iRefHit="88" iRefLayer="5" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-95" iPhiMin="-207" iRefHit="89" iRefLayer="5" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="18" iPhiMin="-94" iRefHit="90" iRefLayer="5" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="18" iPhiMin="-94" iRefHit="91" iRefLayer="5" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="131" iPhiMin="19" iRefHit="92" iRefLayer="5" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="131" iPhiMin="19" iRefHit="93" iRefLayer="5" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="244" iPhiMin="132" iRefHit="94" iRefLayer="5" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="244" iPhiMin="132" iRefHit="95" iRefLayer="5" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-319" iPhiMin="-431" iRefHit="96" iRefLayer="6" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-319" iPhiMin="-431" iRefHit="97" iRefLayer="6" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-206" iPhiMin="-318" iRefHit="98" iRefLayer="6" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-206" iPhiMin="-318" iRefHit="99" iRefLayer="6" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-93" iPhiMin="-205" iRefHit="100" iRefLayer="6" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-93" iPhiMin="-205" iRefHit="101" iRefLayer="6" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="20" iPhiMin="-92" iRefHit="102" iRefLayer="6" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="20" iPhiMin="-92" iRefHit="103" iRefLayer="6" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="133" iPhiMin="21" iRefHit="104" iRefLayer="6" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="133" iPhiMin="21" iRefHit="105" iRefLayer="6" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="246" iPhiMin="134" iRefHit="106" iRefLayer="6" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="246" iPhiMin="134" iRefHit="107" iRefLayer="6" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-358" iPhiMin="-470" iRefHit="108" iRefLayer="7" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-358" iPhiMin="-470" iRefHit="109" iRefLayer="7" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-245" iPhiMin="-357" iRefHit="110" iRefLayer="7" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-245" iPhiMin="-357" iRefHit="111" iRefLayer="7" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-132" iPhiMin="-244" iRefHit="112" iRefLayer="7" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-132" iPhiMin="-244" iRefHit="113" iRefLayer="7" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="-19" iPhiMin="-131" iRefHit="114" iRefLayer="7" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="-19" iPhiMin="-131" iRefHit="115" iRefLayer="7" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="94" iPhiMin="-18" iRefHit="116" iRefLayer="7" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="94" iPhiMin="-18" iRefHit="117" iRefLayer="7" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="207" iPhiMin="95" iRefHit="118" iRefLayer="7" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="207" iPhiMin="95" iRefHit="119" iRefLayer="7" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="120" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="121" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="122" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="123" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="124" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="125" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="126" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="127" iRefLayer="0" iRegion="0"/>
     <LogicRegion iRegion="0">
       <Layer iFirstInput="0" iLayer="0" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="4"/>
@@ -592,22 +707,6 @@
       <Layer iFirstInput="0" iLayer="16" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="17" nInputs="4"/>
     </LogicRegion>
-    <RefHit iInput="0" iPhiMax="-200" iPhiMin="-312" iRefHit="13" iRefLayer="0" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-286" iPhiMin="-398" iRefHit="14" iRefLayer="1" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-225" iPhiMin="-337" iRefHit="15" iRefLayer="2" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-166" iPhiMin="-278" iRefHit="16" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="2" iPhiMax="-166" iPhiMin="-278" iRefHit="17" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="3" iPhiMax="-166" iPhiMin="-278" iRefHit="18" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-167" iPhiMin="-279" iRefHit="19" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-167" iPhiMin="-279" iRefHit="20" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="2" iPhiMax="-167" iPhiMin="-279" iRefHit="21" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="3" iPhiMax="-167" iPhiMin="-279" iRefHit="22" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-208" iPhiMin="-320" iRefHit="23" iRefLayer="5" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-208" iPhiMin="-320" iRefHit="24" iRefLayer="5" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-206" iPhiMin="-318" iRefHit="25" iRefLayer="6" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-206" iPhiMin="-318" iRefHit="26" iRefLayer="6" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-245" iPhiMin="-357" iRefHit="27" iRefLayer="7" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-245" iPhiMin="-357" iRefHit="28" iRefLayer="7" iRegion="1"/>
     <LogicRegion iRegion="1">
       <Layer iFirstInput="0" iLayer="0" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="4"/>
@@ -628,24 +727,6 @@
       <Layer iFirstInput="0" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="0" iPhiMax="-87" iPhiMin="-199" iRefHit="29" iRefLayer="0" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-173" iPhiMin="-285" iRefHit="30" iRefLayer="1" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-112" iPhiMin="-224" iRefHit="31" iRefLayer="2" iRegion="2"/>
-    <RefHit iInput="2" iPhiMax="-112" iPhiMin="-224" iRefHit="32" iRefLayer="2" iRegion="2"/>
-    <RefHit iInput="2" iPhiMax="-53" iPhiMin="-165" iRefHit="33" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="3" iPhiMax="-53" iPhiMin="-165" iRefHit="34" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="4" iPhiMax="-53" iPhiMin="-165" iRefHit="35" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="5" iPhiMax="-53" iPhiMin="-165" iRefHit="36" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="2" iPhiMax="-54" iPhiMin="-166" iRefHit="37" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="3" iPhiMax="-54" iPhiMin="-166" iRefHit="38" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="4" iPhiMax="-54" iPhiMin="-166" iRefHit="39" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="5" iPhiMax="-54" iPhiMin="-166" iRefHit="40" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-95" iPhiMin="-207" iRefHit="41" iRefLayer="5" iRegion="2"/>
-    <RefHit iInput="1" iPhiMax="-95" iPhiMin="-207" iRefHit="42" iRefLayer="5" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-93" iPhiMin="-205" iRefHit="43" iRefLayer="6" iRegion="2"/>
-    <RefHit iInput="1" iPhiMax="-93" iPhiMin="-205" iRefHit="44" iRefLayer="6" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-132" iPhiMin="-244" iRefHit="45" iRefLayer="7" iRegion="2"/>
-    <RefHit iInput="1" iPhiMax="-132" iPhiMin="-244" iRefHit="46" iRefLayer="7" iRegion="2"/>
     <LogicRegion iRegion="2">
       <Layer iFirstInput="0" iLayer="0" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="4"/>
@@ -666,23 +747,6 @@
       <Layer iFirstInput="2" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="2" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="2" iPhiMax="26" iPhiMin="-86" iRefHit="47" iRefLayer="0" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="-60" iPhiMin="-172" iRefHit="48" iRefLayer="1" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="1" iPhiMin="-111" iRefHit="49" iRefLayer="2" iRegion="3"/>
-    <RefHit iInput="4" iPhiMax="60" iPhiMin="-52" iRefHit="50" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="5" iPhiMax="60" iPhiMin="-52" iRefHit="51" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="6" iPhiMax="60" iPhiMin="-52" iRefHit="52" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="7" iPhiMax="60" iPhiMin="-52" iRefHit="53" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="4" iPhiMax="59" iPhiMin="-53" iRefHit="54" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="5" iPhiMax="59" iPhiMin="-53" iRefHit="55" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="6" iPhiMax="59" iPhiMin="-53" iRefHit="56" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="7" iPhiMax="59" iPhiMin="-53" iRefHit="57" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="18" iPhiMin="-94" iRefHit="58" iRefLayer="5" iRegion="3"/>
-    <RefHit iInput="3" iPhiMax="18" iPhiMin="-94" iRefHit="59" iRefLayer="5" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="20" iPhiMin="-92" iRefHit="60" iRefLayer="6" iRegion="3"/>
-    <RefHit iInput="3" iPhiMax="20" iPhiMin="-92" iRefHit="61" iRefLayer="6" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="-19" iPhiMin="-131" iRefHit="62" iRefLayer="7" iRegion="3"/>
-    <RefHit iInput="3" iPhiMax="-19" iPhiMin="-131" iRefHit="63" iRefLayer="7" iRegion="3"/>
     <LogicRegion iRegion="3">
       <Layer iFirstInput="0" iLayer="0" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="6"/>
@@ -703,23 +767,6 @@
       <Layer iFirstInput="4" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="4" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="2" iPhiMax="139" iPhiMin="27" iRefHit="64" iRefLayer="0" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="53" iPhiMin="-59" iRefHit="65" iRefLayer="1" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="114" iPhiMin="2" iRefHit="66" iRefLayer="2" iRegion="4"/>
-    <RefHit iInput="6" iPhiMax="173" iPhiMin="61" iRefHit="67" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="7" iPhiMax="173" iPhiMin="61" iRefHit="68" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="8" iPhiMax="173" iPhiMin="61" iRefHit="69" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="9" iPhiMax="173" iPhiMin="61" iRefHit="70" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="6" iPhiMax="172" iPhiMin="60" iRefHit="71" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="7" iPhiMax="172" iPhiMin="60" iRefHit="72" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="8" iPhiMax="172" iPhiMin="60" iRefHit="73" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="9" iPhiMax="172" iPhiMin="60" iRefHit="74" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="131" iPhiMin="19" iRefHit="75" iRefLayer="5" iRegion="4"/>
-    <RefHit iInput="3" iPhiMax="131" iPhiMin="19" iRefHit="76" iRefLayer="5" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="133" iPhiMin="21" iRefHit="77" iRefLayer="6" iRegion="4"/>
-    <RefHit iInput="3" iPhiMax="133" iPhiMin="21" iRefHit="78" iRefLayer="6" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="94" iPhiMin="-18" iRefHit="79" iRefLayer="7" iRegion="4"/>
-    <RefHit iInput="3" iPhiMax="94" iPhiMin="-18" iRefHit="80" iRefLayer="7" iRegion="4"/>
     <LogicRegion iRegion="4">
       <Layer iFirstInput="0" iLayer="0" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="6"/>
@@ -740,53 +787,6 @@
       <Layer iFirstInput="6" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="6" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="2" iPhiMax="252" iPhiMin="140" iRefHit="81" iRefLayer="0" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="166" iPhiMin="54" iRefHit="82" iRefLayer="1" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="227" iPhiMin="115" iRefHit="83" iRefLayer="2" iRegion="5"/>
-    <RefHit iInput="4" iPhiMax="227" iPhiMin="115" iRefHit="84" iRefLayer="2" iRegion="5"/>
-    <RefHit iInput="8" iPhiMax="286" iPhiMin="174" iRefHit="85" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="9" iPhiMax="286" iPhiMin="174" iRefHit="86" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="10" iPhiMax="286" iPhiMin="174" iRefHit="87" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="11" iPhiMax="286" iPhiMin="174" iRefHit="88" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="8" iPhiMax="285" iPhiMin="173" iRefHit="89" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="9" iPhiMax="285" iPhiMin="173" iRefHit="90" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="10" iPhiMax="285" iPhiMin="173" iRefHit="91" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="11" iPhiMax="285" iPhiMin="173" iRefHit="92" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="244" iPhiMin="132" iRefHit="93" iRefLayer="5" iRegion="5"/>
-    <RefHit iInput="3" iPhiMax="244" iPhiMin="132" iRefHit="94" iRefLayer="5" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="246" iPhiMin="134" iRefHit="95" iRefLayer="6" iRegion="5"/>
-    <RefHit iInput="3" iPhiMax="246" iPhiMin="134" iRefHit="96" iRefLayer="6" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="207" iPhiMin="95" iRefHit="97" iRefLayer="7" iRegion="5"/>
-    <RefHit iInput="3" iPhiMax="207" iPhiMin="95" iRefHit="98" iRefLayer="7" iRegion="5"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="99" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="100" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="101" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="102" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="103" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="104" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="105" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="106" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="107" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="108" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="109" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="110" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="111" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="112" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="113" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="114" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="115" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="116" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="117" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="118" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="119" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="120" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="121" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="122" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="123" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="124" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="125" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="126" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="127" iRefLayer="0" iRegion="0"/>
     <LogicRegion iRegion="5">
       <Layer iFirstInput="0" iLayer="0" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="6"/>
@@ -819,18 +819,133 @@
     <RefLayer iGlobalPhiStart="1948" iRefLayer="6"/>
     <RefLayer iGlobalPhiStart="1910" iRefLayer="7"/>
     <RefHit iInput="0" iPhiMax="-311" iPhiMin="-423" iRefHit="0" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-399" iPhiMin="-511" iRefHit="1" iRefLayer="1" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-348" iPhiMin="-460" iRefHit="2" iRefLayer="2" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-279" iPhiMin="-391" iRefHit="3" iRefLayer="3" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-279" iPhiMin="-391" iRefHit="4" iRefLayer="3" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-281" iPhiMin="-393" iRefHit="5" iRefLayer="4" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-281" iPhiMin="-393" iRefHit="6" iRefLayer="4" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-321" iPhiMin="-433" iRefHit="7" iRefLayer="5" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-321" iPhiMin="-433" iRefHit="8" iRefLayer="5" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-320" iPhiMin="-432" iRefHit="9" iRefLayer="6" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-320" iPhiMin="-432" iRefHit="10" iRefLayer="6" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-358" iPhiMin="-470" iRefHit="11" iRefLayer="7" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-358" iPhiMin="-470" iRefHit="12" iRefLayer="7" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-311" iPhiMin="-423" iRefHit="1" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-198" iPhiMin="-310" iRefHit="2" iRefLayer="0" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-198" iPhiMin="-310" iRefHit="3" iRefLayer="0" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-85" iPhiMin="-197" iRefHit="4" iRefLayer="0" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-85" iPhiMin="-197" iRefHit="5" iRefLayer="0" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="28" iPhiMin="-84" iRefHit="6" iRefLayer="0" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="28" iPhiMin="-84" iRefHit="7" iRefLayer="0" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="141" iPhiMin="29" iRefHit="8" iRefLayer="0" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="141" iPhiMin="29" iRefHit="9" iRefLayer="0" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="254" iPhiMin="142" iRefHit="10" iRefLayer="0" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="254" iPhiMin="142" iRefHit="11" iRefLayer="0" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-399" iPhiMin="-511" iRefHit="12" iRefLayer="1" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-399" iPhiMin="-511" iRefHit="13" iRefLayer="1" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-286" iPhiMin="-398" iRefHit="14" iRefLayer="1" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-286" iPhiMin="-398" iRefHit="15" iRefLayer="1" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-173" iPhiMin="-285" iRefHit="16" iRefLayer="1" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-173" iPhiMin="-285" iRefHit="17" iRefLayer="1" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="-60" iPhiMin="-172" iRefHit="18" iRefLayer="1" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="-60" iPhiMin="-172" iRefHit="19" iRefLayer="1" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="53" iPhiMin="-59" iRefHit="20" iRefLayer="1" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="53" iPhiMin="-59" iRefHit="21" iRefLayer="1" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="166" iPhiMin="54" iRefHit="22" iRefLayer="1" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="166" iPhiMin="54" iRefHit="23" iRefLayer="1" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-348" iPhiMin="-460" iRefHit="24" iRefLayer="2" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-348" iPhiMin="-460" iRefHit="25" iRefLayer="2" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-235" iPhiMin="-347" iRefHit="26" iRefLayer="2" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-235" iPhiMin="-347" iRefHit="27" iRefLayer="2" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-122" iPhiMin="-234" iRefHit="28" iRefLayer="2" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-122" iPhiMin="-234" iRefHit="29" iRefLayer="2" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="-122" iPhiMin="-234" iRefHit="30" iRefLayer="2" iRegion="2"/>
+    <RefHit iInput="3" iPhiMax="-122" iPhiMin="-234" iRefHit="31" iRefLayer="2" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="-9" iPhiMin="-121" iRefHit="32" iRefLayer="2" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="-9" iPhiMin="-121" iRefHit="33" iRefLayer="2" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="104" iPhiMin="-8" iRefHit="34" iRefLayer="2" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="104" iPhiMin="-8" iRefHit="35" iRefLayer="2" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="217" iPhiMin="105" iRefHit="36" iRefLayer="2" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="217" iPhiMin="105" iRefHit="37" iRefLayer="2" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-279" iPhiMin="-391" iRefHit="38" iRefLayer="3" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-279" iPhiMin="-391" iRefHit="39" iRefLayer="3" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-166" iPhiMin="-278" iRefHit="40" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-166" iPhiMin="-278" iRefHit="41" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-166" iPhiMin="-278" iRefHit="42" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="3" iPhiMax="-166" iPhiMin="-278" iRefHit="43" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-53" iPhiMin="-165" iRefHit="44" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="3" iPhiMax="-53" iPhiMin="-165" iRefHit="45" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="-53" iPhiMin="-165" iRefHit="46" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="5" iPhiMax="-53" iPhiMin="-165" iRefHit="47" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="60" iPhiMin="-52" iRefHit="48" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="5" iPhiMax="60" iPhiMin="-52" iRefHit="49" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="60" iPhiMin="-52" iRefHit="50" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="7" iPhiMax="60" iPhiMin="-52" iRefHit="51" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="173" iPhiMin="61" iRefHit="52" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="7" iPhiMax="173" iPhiMin="61" iRefHit="53" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="173" iPhiMin="61" iRefHit="54" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="9" iPhiMax="173" iPhiMin="61" iRefHit="55" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="286" iPhiMin="174" iRefHit="56" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="9" iPhiMax="286" iPhiMin="174" iRefHit="57" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="10" iPhiMax="286" iPhiMin="174" iRefHit="58" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="11" iPhiMax="286" iPhiMin="174" iRefHit="59" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-281" iPhiMin="-393" iRefHit="60" iRefLayer="4" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-281" iPhiMin="-393" iRefHit="61" iRefLayer="4" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-168" iPhiMin="-280" iRefHit="62" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-168" iPhiMin="-280" iRefHit="63" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-168" iPhiMin="-280" iRefHit="64" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="3" iPhiMax="-168" iPhiMin="-280" iRefHit="65" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-55" iPhiMin="-167" iRefHit="66" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="3" iPhiMax="-55" iPhiMin="-167" iRefHit="67" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="-55" iPhiMin="-167" iRefHit="68" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="5" iPhiMax="-55" iPhiMin="-167" iRefHit="69" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="58" iPhiMin="-54" iRefHit="70" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="5" iPhiMax="58" iPhiMin="-54" iRefHit="71" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="58" iPhiMin="-54" iRefHit="72" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="7" iPhiMax="58" iPhiMin="-54" iRefHit="73" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="171" iPhiMin="59" iRefHit="74" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="7" iPhiMax="171" iPhiMin="59" iRefHit="75" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="171" iPhiMin="59" iRefHit="76" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="9" iPhiMax="171" iPhiMin="59" iRefHit="77" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="284" iPhiMin="172" iRefHit="78" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="9" iPhiMax="284" iPhiMin="172" iRefHit="79" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="10" iPhiMax="284" iPhiMin="172" iRefHit="80" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="11" iPhiMax="284" iPhiMin="172" iRefHit="81" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-321" iPhiMin="-433" iRefHit="82" iRefLayer="5" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-321" iPhiMin="-433" iRefHit="83" iRefLayer="5" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-208" iPhiMin="-320" iRefHit="84" iRefLayer="5" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-208" iPhiMin="-320" iRefHit="85" iRefLayer="5" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-95" iPhiMin="-207" iRefHit="86" iRefLayer="5" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-95" iPhiMin="-207" iRefHit="87" iRefLayer="5" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="18" iPhiMin="-94" iRefHit="88" iRefLayer="5" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="18" iPhiMin="-94" iRefHit="89" iRefLayer="5" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="131" iPhiMin="19" iRefHit="90" iRefLayer="5" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="131" iPhiMin="19" iRefHit="91" iRefLayer="5" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="244" iPhiMin="132" iRefHit="92" iRefLayer="5" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="244" iPhiMin="132" iRefHit="93" iRefLayer="5" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-320" iPhiMin="-432" iRefHit="94" iRefLayer="6" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-320" iPhiMin="-432" iRefHit="95" iRefLayer="6" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-207" iPhiMin="-319" iRefHit="96" iRefLayer="6" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-207" iPhiMin="-319" iRefHit="97" iRefLayer="6" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-94" iPhiMin="-206" iRefHit="98" iRefLayer="6" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-94" iPhiMin="-206" iRefHit="99" iRefLayer="6" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="19" iPhiMin="-93" iRefHit="100" iRefLayer="6" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="19" iPhiMin="-93" iRefHit="101" iRefLayer="6" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="132" iPhiMin="20" iRefHit="102" iRefLayer="6" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="132" iPhiMin="20" iRefHit="103" iRefLayer="6" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="245" iPhiMin="133" iRefHit="104" iRefLayer="6" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="245" iPhiMin="133" iRefHit="105" iRefLayer="6" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-358" iPhiMin="-470" iRefHit="106" iRefLayer="7" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-358" iPhiMin="-470" iRefHit="107" iRefLayer="7" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-245" iPhiMin="-357" iRefHit="108" iRefLayer="7" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-245" iPhiMin="-357" iRefHit="109" iRefLayer="7" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-132" iPhiMin="-244" iRefHit="110" iRefLayer="7" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-132" iPhiMin="-244" iRefHit="111" iRefLayer="7" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="-19" iPhiMin="-131" iRefHit="112" iRefLayer="7" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="-19" iPhiMin="-131" iRefHit="113" iRefLayer="7" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="94" iPhiMin="-18" iRefHit="114" iRefLayer="7" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="94" iPhiMin="-18" iRefHit="115" iRefLayer="7" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="207" iPhiMin="95" iRefHit="116" iRefLayer="7" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="207" iPhiMin="95" iRefHit="117" iRefLayer="7" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="118" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="119" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="120" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="121" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="122" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="123" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="124" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="125" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="126" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="127" iRefLayer="0" iRegion="0"/>
     <LogicRegion iRegion="0">
       <Layer iFirstInput="0" iLayer="0" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="4"/>
@@ -851,23 +966,6 @@
       <Layer iFirstInput="0" iLayer="16" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="17" nInputs="4"/>
     </LogicRegion>
-    <RefHit iInput="0" iPhiMax="-198" iPhiMin="-310" iRefHit="13" iRefLayer="0" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-286" iPhiMin="-398" iRefHit="14" iRefLayer="1" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-235" iPhiMin="-347" iRefHit="15" iRefLayer="2" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-166" iPhiMin="-278" iRefHit="16" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-166" iPhiMin="-278" iRefHit="17" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="2" iPhiMax="-166" iPhiMin="-278" iRefHit="18" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="3" iPhiMax="-166" iPhiMin="-278" iRefHit="19" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-168" iPhiMin="-280" iRefHit="20" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-168" iPhiMin="-280" iRefHit="21" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="2" iPhiMax="-168" iPhiMin="-280" iRefHit="22" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="3" iPhiMax="-168" iPhiMin="-280" iRefHit="23" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-208" iPhiMin="-320" iRefHit="24" iRefLayer="5" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-208" iPhiMin="-320" iRefHit="25" iRefLayer="5" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-207" iPhiMin="-319" iRefHit="26" iRefLayer="6" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-207" iPhiMin="-319" iRefHit="27" iRefLayer="6" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-245" iPhiMin="-357" iRefHit="28" iRefLayer="7" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-245" iPhiMin="-357" iRefHit="29" iRefLayer="7" iRegion="1"/>
     <LogicRegion iRegion="1">
       <Layer iFirstInput="0" iLayer="0" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="4"/>
@@ -888,24 +986,6 @@
       <Layer iFirstInput="0" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="0" iPhiMax="-85" iPhiMin="-197" iRefHit="30" iRefLayer="0" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-173" iPhiMin="-285" iRefHit="31" iRefLayer="1" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-122" iPhiMin="-234" iRefHit="32" iRefLayer="2" iRegion="2"/>
-    <RefHit iInput="2" iPhiMax="-122" iPhiMin="-234" iRefHit="33" iRefLayer="2" iRegion="2"/>
-    <RefHit iInput="2" iPhiMax="-53" iPhiMin="-165" iRefHit="34" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="3" iPhiMax="-53" iPhiMin="-165" iRefHit="35" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="4" iPhiMax="-53" iPhiMin="-165" iRefHit="36" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="5" iPhiMax="-53" iPhiMin="-165" iRefHit="37" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="2" iPhiMax="-55" iPhiMin="-167" iRefHit="38" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="3" iPhiMax="-55" iPhiMin="-167" iRefHit="39" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="4" iPhiMax="-55" iPhiMin="-167" iRefHit="40" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="5" iPhiMax="-55" iPhiMin="-167" iRefHit="41" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-95" iPhiMin="-207" iRefHit="42" iRefLayer="5" iRegion="2"/>
-    <RefHit iInput="1" iPhiMax="-95" iPhiMin="-207" iRefHit="43" iRefLayer="5" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-94" iPhiMin="-206" iRefHit="44" iRefLayer="6" iRegion="2"/>
-    <RefHit iInput="1" iPhiMax="-94" iPhiMin="-206" iRefHit="45" iRefLayer="6" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-132" iPhiMin="-244" iRefHit="46" iRefLayer="7" iRegion="2"/>
-    <RefHit iInput="1" iPhiMax="-132" iPhiMin="-244" iRefHit="47" iRefLayer="7" iRegion="2"/>
     <LogicRegion iRegion="2">
       <Layer iFirstInput="0" iLayer="0" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="4"/>
@@ -926,23 +1006,6 @@
       <Layer iFirstInput="2" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="2" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="2" iPhiMax="28" iPhiMin="-84" iRefHit="48" iRefLayer="0" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="-60" iPhiMin="-172" iRefHit="49" iRefLayer="1" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="-9" iPhiMin="-121" iRefHit="50" iRefLayer="2" iRegion="3"/>
-    <RefHit iInput="4" iPhiMax="60" iPhiMin="-52" iRefHit="51" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="5" iPhiMax="60" iPhiMin="-52" iRefHit="52" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="6" iPhiMax="60" iPhiMin="-52" iRefHit="53" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="7" iPhiMax="60" iPhiMin="-52" iRefHit="54" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="4" iPhiMax="58" iPhiMin="-54" iRefHit="55" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="5" iPhiMax="58" iPhiMin="-54" iRefHit="56" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="6" iPhiMax="58" iPhiMin="-54" iRefHit="57" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="7" iPhiMax="58" iPhiMin="-54" iRefHit="58" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="18" iPhiMin="-94" iRefHit="59" iRefLayer="5" iRegion="3"/>
-    <RefHit iInput="3" iPhiMax="18" iPhiMin="-94" iRefHit="60" iRefLayer="5" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="19" iPhiMin="-93" iRefHit="61" iRefLayer="6" iRegion="3"/>
-    <RefHit iInput="3" iPhiMax="19" iPhiMin="-93" iRefHit="62" iRefLayer="6" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="-19" iPhiMin="-131" iRefHit="63" iRefLayer="7" iRegion="3"/>
-    <RefHit iInput="3" iPhiMax="-19" iPhiMin="-131" iRefHit="64" iRefLayer="7" iRegion="3"/>
     <LogicRegion iRegion="3">
       <Layer iFirstInput="0" iLayer="0" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="6"/>
@@ -963,23 +1026,6 @@
       <Layer iFirstInput="4" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="4" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="2" iPhiMax="141" iPhiMin="29" iRefHit="65" iRefLayer="0" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="53" iPhiMin="-59" iRefHit="66" iRefLayer="1" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="104" iPhiMin="-8" iRefHit="67" iRefLayer="2" iRegion="4"/>
-    <RefHit iInput="6" iPhiMax="173" iPhiMin="61" iRefHit="68" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="7" iPhiMax="173" iPhiMin="61" iRefHit="69" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="8" iPhiMax="173" iPhiMin="61" iRefHit="70" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="9" iPhiMax="173" iPhiMin="61" iRefHit="71" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="6" iPhiMax="171" iPhiMin="59" iRefHit="72" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="7" iPhiMax="171" iPhiMin="59" iRefHit="73" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="8" iPhiMax="171" iPhiMin="59" iRefHit="74" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="9" iPhiMax="171" iPhiMin="59" iRefHit="75" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="131" iPhiMin="19" iRefHit="76" iRefLayer="5" iRegion="4"/>
-    <RefHit iInput="3" iPhiMax="131" iPhiMin="19" iRefHit="77" iRefLayer="5" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="132" iPhiMin="20" iRefHit="78" iRefLayer="6" iRegion="4"/>
-    <RefHit iInput="3" iPhiMax="132" iPhiMin="20" iRefHit="79" iRefLayer="6" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="94" iPhiMin="-18" iRefHit="80" iRefLayer="7" iRegion="4"/>
-    <RefHit iInput="3" iPhiMax="94" iPhiMin="-18" iRefHit="81" iRefLayer="7" iRegion="4"/>
     <LogicRegion iRegion="4">
       <Layer iFirstInput="0" iLayer="0" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="6"/>
@@ -1000,52 +1046,6 @@
       <Layer iFirstInput="6" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="6" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="2" iPhiMax="254" iPhiMin="142" iRefHit="82" iRefLayer="0" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="166" iPhiMin="54" iRefHit="83" iRefLayer="1" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="217" iPhiMin="105" iRefHit="84" iRefLayer="2" iRegion="5"/>
-    <RefHit iInput="8" iPhiMax="286" iPhiMin="174" iRefHit="85" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="9" iPhiMax="286" iPhiMin="174" iRefHit="86" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="10" iPhiMax="286" iPhiMin="174" iRefHit="87" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="11" iPhiMax="286" iPhiMin="174" iRefHit="88" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="8" iPhiMax="284" iPhiMin="172" iRefHit="89" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="9" iPhiMax="284" iPhiMin="172" iRefHit="90" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="10" iPhiMax="284" iPhiMin="172" iRefHit="91" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="11" iPhiMax="284" iPhiMin="172" iRefHit="92" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="244" iPhiMin="132" iRefHit="93" iRefLayer="5" iRegion="5"/>
-    <RefHit iInput="3" iPhiMax="244" iPhiMin="132" iRefHit="94" iRefLayer="5" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="245" iPhiMin="133" iRefHit="95" iRefLayer="6" iRegion="5"/>
-    <RefHit iInput="3" iPhiMax="245" iPhiMin="133" iRefHit="96" iRefLayer="6" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="207" iPhiMin="95" iRefHit="97" iRefLayer="7" iRegion="5"/>
-    <RefHit iInput="3" iPhiMax="207" iPhiMin="95" iRefHit="98" iRefLayer="7" iRegion="5"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="99" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="100" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="101" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="102" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="103" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="104" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="105" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="106" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="107" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="108" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="109" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="110" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="111" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="112" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="113" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="114" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="115" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="116" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="117" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="118" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="119" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="120" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="121" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="122" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="123" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="124" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="125" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="126" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="127" iRefLayer="0" iRegion="0"/>
     <LogicRegion iRegion="5">
       <Layer iFirstInput="0" iLayer="0" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="6"/>
@@ -1078,18 +1078,133 @@
     <RefLayer iGlobalPhiStart="-1465" iRefLayer="6"/>
     <RefLayer iGlobalPhiStart="-1501" iRefLayer="7"/>
     <RefHit iInput="0" iPhiMax="-312" iPhiMin="-424" iRefHit="0" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-399" iPhiMin="-511" iRefHit="1" iRefLayer="1" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-346" iPhiMin="-458" iRefHit="2" iRefLayer="2" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-279" iPhiMin="-391" iRefHit="3" iRefLayer="3" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-279" iPhiMin="-391" iRefHit="4" iRefLayer="3" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-280" iPhiMin="-392" iRefHit="5" iRefLayer="4" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-280" iPhiMin="-392" iRefHit="6" iRefLayer="4" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-320" iPhiMin="-432" iRefHit="7" iRefLayer="5" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-320" iPhiMin="-432" iRefHit="8" iRefLayer="5" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-319" iPhiMin="-431" iRefHit="9" iRefLayer="6" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-319" iPhiMin="-431" iRefHit="10" iRefLayer="6" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-355" iPhiMin="-467" iRefHit="11" iRefLayer="7" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-355" iPhiMin="-467" iRefHit="12" iRefLayer="7" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-312" iPhiMin="-424" iRefHit="1" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-199" iPhiMin="-311" iRefHit="2" iRefLayer="0" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-199" iPhiMin="-311" iRefHit="3" iRefLayer="0" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-86" iPhiMin="-198" iRefHit="4" iRefLayer="0" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-86" iPhiMin="-198" iRefHit="5" iRefLayer="0" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="27" iPhiMin="-85" iRefHit="6" iRefLayer="0" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="27" iPhiMin="-85" iRefHit="7" iRefLayer="0" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="140" iPhiMin="28" iRefHit="8" iRefLayer="0" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="140" iPhiMin="28" iRefHit="9" iRefLayer="0" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="253" iPhiMin="141" iRefHit="10" iRefLayer="0" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="253" iPhiMin="141" iRefHit="11" iRefLayer="0" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-399" iPhiMin="-511" iRefHit="12" iRefLayer="1" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-399" iPhiMin="-511" iRefHit="13" iRefLayer="1" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-286" iPhiMin="-398" iRefHit="14" iRefLayer="1" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-286" iPhiMin="-398" iRefHit="15" iRefLayer="1" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-173" iPhiMin="-285" iRefHit="16" iRefLayer="1" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-173" iPhiMin="-285" iRefHit="17" iRefLayer="1" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="-60" iPhiMin="-172" iRefHit="18" iRefLayer="1" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="-60" iPhiMin="-172" iRefHit="19" iRefLayer="1" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="53" iPhiMin="-59" iRefHit="20" iRefLayer="1" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="53" iPhiMin="-59" iRefHit="21" iRefLayer="1" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="166" iPhiMin="54" iRefHit="22" iRefLayer="1" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="166" iPhiMin="54" iRefHit="23" iRefLayer="1" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-346" iPhiMin="-458" iRefHit="24" iRefLayer="2" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-346" iPhiMin="-458" iRefHit="25" iRefLayer="2" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-233" iPhiMin="-345" iRefHit="26" iRefLayer="2" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-233" iPhiMin="-345" iRefHit="27" iRefLayer="2" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-120" iPhiMin="-232" iRefHit="28" iRefLayer="2" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-120" iPhiMin="-232" iRefHit="29" iRefLayer="2" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="-7" iPhiMin="-119" iRefHit="30" iRefLayer="2" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="-7" iPhiMin="-119" iRefHit="31" iRefLayer="2" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="106" iPhiMin="-6" iRefHit="32" iRefLayer="2" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="106" iPhiMin="-6" iRefHit="33" iRefLayer="2" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="219" iPhiMin="107" iRefHit="34" iRefLayer="2" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="219" iPhiMin="107" iRefHit="35" iRefLayer="2" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-279" iPhiMin="-391" iRefHit="36" iRefLayer="3" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-279" iPhiMin="-391" iRefHit="37" iRefLayer="3" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-166" iPhiMin="-278" iRefHit="38" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-166" iPhiMin="-278" iRefHit="39" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-166" iPhiMin="-278" iRefHit="40" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="3" iPhiMax="-166" iPhiMin="-278" iRefHit="41" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-53" iPhiMin="-165" iRefHit="42" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="3" iPhiMax="-53" iPhiMin="-165" iRefHit="43" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="-53" iPhiMin="-165" iRefHit="44" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="5" iPhiMax="-53" iPhiMin="-165" iRefHit="45" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="60" iPhiMin="-52" iRefHit="46" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="5" iPhiMax="60" iPhiMin="-52" iRefHit="47" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="60" iPhiMin="-52" iRefHit="48" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="7" iPhiMax="60" iPhiMin="-52" iRefHit="49" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="173" iPhiMin="61" iRefHit="50" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="7" iPhiMax="173" iPhiMin="61" iRefHit="51" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="173" iPhiMin="61" iRefHit="52" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="9" iPhiMax="173" iPhiMin="61" iRefHit="53" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="286" iPhiMin="174" iRefHit="54" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="9" iPhiMax="286" iPhiMin="174" iRefHit="55" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="10" iPhiMax="286" iPhiMin="174" iRefHit="56" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="11" iPhiMax="286" iPhiMin="174" iRefHit="57" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-280" iPhiMin="-392" iRefHit="58" iRefLayer="4" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-280" iPhiMin="-392" iRefHit="59" iRefLayer="4" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-167" iPhiMin="-279" iRefHit="60" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-167" iPhiMin="-279" iRefHit="61" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-167" iPhiMin="-279" iRefHit="62" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="3" iPhiMax="-167" iPhiMin="-279" iRefHit="63" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-54" iPhiMin="-166" iRefHit="64" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="3" iPhiMax="-54" iPhiMin="-166" iRefHit="65" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="-54" iPhiMin="-166" iRefHit="66" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="5" iPhiMax="-54" iPhiMin="-166" iRefHit="67" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="59" iPhiMin="-53" iRefHit="68" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="5" iPhiMax="59" iPhiMin="-53" iRefHit="69" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="59" iPhiMin="-53" iRefHit="70" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="7" iPhiMax="59" iPhiMin="-53" iRefHit="71" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="172" iPhiMin="60" iRefHit="72" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="7" iPhiMax="172" iPhiMin="60" iRefHit="73" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="172" iPhiMin="60" iRefHit="74" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="9" iPhiMax="172" iPhiMin="60" iRefHit="75" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="285" iPhiMin="173" iRefHit="76" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="9" iPhiMax="285" iPhiMin="173" iRefHit="77" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="10" iPhiMax="285" iPhiMin="173" iRefHit="78" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="11" iPhiMax="285" iPhiMin="173" iRefHit="79" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-320" iPhiMin="-432" iRefHit="80" iRefLayer="5" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-320" iPhiMin="-432" iRefHit="81" iRefLayer="5" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-207" iPhiMin="-319" iRefHit="82" iRefLayer="5" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-207" iPhiMin="-319" iRefHit="83" iRefLayer="5" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-94" iPhiMin="-206" iRefHit="84" iRefLayer="5" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-94" iPhiMin="-206" iRefHit="85" iRefLayer="5" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="19" iPhiMin="-93" iRefHit="86" iRefLayer="5" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="19" iPhiMin="-93" iRefHit="87" iRefLayer="5" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="132" iPhiMin="20" iRefHit="88" iRefLayer="5" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="132" iPhiMin="20" iRefHit="89" iRefLayer="5" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="245" iPhiMin="133" iRefHit="90" iRefLayer="5" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="245" iPhiMin="133" iRefHit="91" iRefLayer="5" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-319" iPhiMin="-431" iRefHit="92" iRefLayer="6" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-319" iPhiMin="-431" iRefHit="93" iRefLayer="6" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-206" iPhiMin="-318" iRefHit="94" iRefLayer="6" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-206" iPhiMin="-318" iRefHit="95" iRefLayer="6" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-93" iPhiMin="-205" iRefHit="96" iRefLayer="6" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-93" iPhiMin="-205" iRefHit="97" iRefLayer="6" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="20" iPhiMin="-92" iRefHit="98" iRefLayer="6" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="20" iPhiMin="-92" iRefHit="99" iRefLayer="6" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="133" iPhiMin="21" iRefHit="100" iRefLayer="6" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="133" iPhiMin="21" iRefHit="101" iRefLayer="6" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="246" iPhiMin="134" iRefHit="102" iRefLayer="6" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="246" iPhiMin="134" iRefHit="103" iRefLayer="6" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-355" iPhiMin="-467" iRefHit="104" iRefLayer="7" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-355" iPhiMin="-467" iRefHit="105" iRefLayer="7" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-242" iPhiMin="-354" iRefHit="106" iRefLayer="7" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-242" iPhiMin="-354" iRefHit="107" iRefLayer="7" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-129" iPhiMin="-241" iRefHit="108" iRefLayer="7" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-129" iPhiMin="-241" iRefHit="109" iRefLayer="7" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="-16" iPhiMin="-128" iRefHit="110" iRefLayer="7" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="-16" iPhiMin="-128" iRefHit="111" iRefLayer="7" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="97" iPhiMin="-15" iRefHit="112" iRefLayer="7" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="97" iPhiMin="-15" iRefHit="113" iRefLayer="7" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="210" iPhiMin="98" iRefHit="114" iRefLayer="7" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="210" iPhiMin="98" iRefHit="115" iRefLayer="7" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="116" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="117" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="118" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="119" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="120" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="121" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="122" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="123" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="124" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="125" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="126" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="127" iRefLayer="0" iRegion="0"/>
     <LogicRegion iRegion="0">
       <Layer iFirstInput="0" iLayer="0" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="4"/>
@@ -1110,22 +1225,6 @@
       <Layer iFirstInput="0" iLayer="16" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="17" nInputs="4"/>
     </LogicRegion>
-    <RefHit iInput="0" iPhiMax="-199" iPhiMin="-311" iRefHit="13" iRefLayer="0" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-286" iPhiMin="-398" iRefHit="14" iRefLayer="1" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-233" iPhiMin="-345" iRefHit="15" iRefLayer="2" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-166" iPhiMin="-278" iRefHit="16" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="2" iPhiMax="-166" iPhiMin="-278" iRefHit="17" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="3" iPhiMax="-166" iPhiMin="-278" iRefHit="18" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-167" iPhiMin="-279" iRefHit="19" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-167" iPhiMin="-279" iRefHit="20" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="2" iPhiMax="-167" iPhiMin="-279" iRefHit="21" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="3" iPhiMax="-167" iPhiMin="-279" iRefHit="22" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-207" iPhiMin="-319" iRefHit="23" iRefLayer="5" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-207" iPhiMin="-319" iRefHit="24" iRefLayer="5" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-206" iPhiMin="-318" iRefHit="25" iRefLayer="6" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-206" iPhiMin="-318" iRefHit="26" iRefLayer="6" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-242" iPhiMin="-354" iRefHit="27" iRefLayer="7" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-242" iPhiMin="-354" iRefHit="28" iRefLayer="7" iRegion="1"/>
     <LogicRegion iRegion="1">
       <Layer iFirstInput="0" iLayer="0" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="4"/>
@@ -1146,24 +1245,6 @@
       <Layer iFirstInput="0" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="0" iPhiMax="-86" iPhiMin="-198" iRefHit="29" iRefLayer="0" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-173" iPhiMin="-285" iRefHit="30" iRefLayer="1" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-120" iPhiMin="-232" iRefHit="31" iRefLayer="2" iRegion="2"/>
-    <RefHit iInput="2" iPhiMax="-120" iPhiMin="-232" iRefHit="32" iRefLayer="2" iRegion="2"/>
-    <RefHit iInput="2" iPhiMax="-53" iPhiMin="-165" iRefHit="33" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="3" iPhiMax="-53" iPhiMin="-165" iRefHit="34" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="4" iPhiMax="-53" iPhiMin="-165" iRefHit="35" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="5" iPhiMax="-53" iPhiMin="-165" iRefHit="36" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="2" iPhiMax="-54" iPhiMin="-166" iRefHit="37" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="3" iPhiMax="-54" iPhiMin="-166" iRefHit="38" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="4" iPhiMax="-54" iPhiMin="-166" iRefHit="39" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="5" iPhiMax="-54" iPhiMin="-166" iRefHit="40" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-94" iPhiMin="-206" iRefHit="41" iRefLayer="5" iRegion="2"/>
-    <RefHit iInput="1" iPhiMax="-94" iPhiMin="-206" iRefHit="42" iRefLayer="5" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-93" iPhiMin="-205" iRefHit="43" iRefLayer="6" iRegion="2"/>
-    <RefHit iInput="1" iPhiMax="-93" iPhiMin="-205" iRefHit="44" iRefLayer="6" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-129" iPhiMin="-241" iRefHit="45" iRefLayer="7" iRegion="2"/>
-    <RefHit iInput="1" iPhiMax="-129" iPhiMin="-241" iRefHit="46" iRefLayer="7" iRegion="2"/>
     <LogicRegion iRegion="2">
       <Layer iFirstInput="0" iLayer="0" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="4"/>
@@ -1184,23 +1265,6 @@
       <Layer iFirstInput="2" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="2" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="2" iPhiMax="27" iPhiMin="-85" iRefHit="47" iRefLayer="0" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="-60" iPhiMin="-172" iRefHit="48" iRefLayer="1" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="-7" iPhiMin="-119" iRefHit="49" iRefLayer="2" iRegion="3"/>
-    <RefHit iInput="4" iPhiMax="60" iPhiMin="-52" iRefHit="50" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="5" iPhiMax="60" iPhiMin="-52" iRefHit="51" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="6" iPhiMax="60" iPhiMin="-52" iRefHit="52" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="7" iPhiMax="60" iPhiMin="-52" iRefHit="53" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="4" iPhiMax="59" iPhiMin="-53" iRefHit="54" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="5" iPhiMax="59" iPhiMin="-53" iRefHit="55" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="6" iPhiMax="59" iPhiMin="-53" iRefHit="56" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="7" iPhiMax="59" iPhiMin="-53" iRefHit="57" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="19" iPhiMin="-93" iRefHit="58" iRefLayer="5" iRegion="3"/>
-    <RefHit iInput="3" iPhiMax="19" iPhiMin="-93" iRefHit="59" iRefLayer="5" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="20" iPhiMin="-92" iRefHit="60" iRefLayer="6" iRegion="3"/>
-    <RefHit iInput="3" iPhiMax="20" iPhiMin="-92" iRefHit="61" iRefLayer="6" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="-16" iPhiMin="-128" iRefHit="62" iRefLayer="7" iRegion="3"/>
-    <RefHit iInput="3" iPhiMax="-16" iPhiMin="-128" iRefHit="63" iRefLayer="7" iRegion="3"/>
     <LogicRegion iRegion="3">
       <Layer iFirstInput="0" iLayer="0" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="6"/>
@@ -1221,23 +1285,6 @@
       <Layer iFirstInput="4" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="4" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="2" iPhiMax="140" iPhiMin="28" iRefHit="64" iRefLayer="0" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="53" iPhiMin="-59" iRefHit="65" iRefLayer="1" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="106" iPhiMin="-6" iRefHit="66" iRefLayer="2" iRegion="4"/>
-    <RefHit iInput="6" iPhiMax="173" iPhiMin="61" iRefHit="67" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="7" iPhiMax="173" iPhiMin="61" iRefHit="68" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="8" iPhiMax="173" iPhiMin="61" iRefHit="69" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="9" iPhiMax="173" iPhiMin="61" iRefHit="70" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="6" iPhiMax="172" iPhiMin="60" iRefHit="71" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="7" iPhiMax="172" iPhiMin="60" iRefHit="72" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="8" iPhiMax="172" iPhiMin="60" iRefHit="73" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="9" iPhiMax="172" iPhiMin="60" iRefHit="74" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="132" iPhiMin="20" iRefHit="75" iRefLayer="5" iRegion="4"/>
-    <RefHit iInput="3" iPhiMax="132" iPhiMin="20" iRefHit="76" iRefLayer="5" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="133" iPhiMin="21" iRefHit="77" iRefLayer="6" iRegion="4"/>
-    <RefHit iInput="3" iPhiMax="133" iPhiMin="21" iRefHit="78" iRefLayer="6" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="97" iPhiMin="-15" iRefHit="79" iRefLayer="7" iRegion="4"/>
-    <RefHit iInput="3" iPhiMax="97" iPhiMin="-15" iRefHit="80" iRefLayer="7" iRegion="4"/>
     <LogicRegion iRegion="4">
       <Layer iFirstInput="0" iLayer="0" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="6"/>
@@ -1258,53 +1305,6 @@
       <Layer iFirstInput="6" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="6" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="2" iPhiMax="253" iPhiMin="141" iRefHit="81" iRefLayer="0" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="166" iPhiMin="54" iRefHit="82" iRefLayer="1" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="219" iPhiMin="107" iRefHit="83" iRefLayer="2" iRegion="5"/>
-    <RefHit iInput="8" iPhiMax="286" iPhiMin="174" iRefHit="84" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="9" iPhiMax="286" iPhiMin="174" iRefHit="85" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="10" iPhiMax="286" iPhiMin="174" iRefHit="86" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="11" iPhiMax="286" iPhiMin="174" iRefHit="87" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="8" iPhiMax="285" iPhiMin="173" iRefHit="88" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="9" iPhiMax="285" iPhiMin="173" iRefHit="89" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="10" iPhiMax="285" iPhiMin="173" iRefHit="90" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="11" iPhiMax="285" iPhiMin="173" iRefHit="91" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="245" iPhiMin="133" iRefHit="92" iRefLayer="5" iRegion="5"/>
-    <RefHit iInput="3" iPhiMax="245" iPhiMin="133" iRefHit="93" iRefLayer="5" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="246" iPhiMin="134" iRefHit="94" iRefLayer="6" iRegion="5"/>
-    <RefHit iInput="3" iPhiMax="246" iPhiMin="134" iRefHit="95" iRefLayer="6" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="210" iPhiMin="98" iRefHit="96" iRefLayer="7" iRegion="5"/>
-    <RefHit iInput="3" iPhiMax="210" iPhiMin="98" iRefHit="97" iRefLayer="7" iRegion="5"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="98" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="99" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="100" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="101" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="102" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="103" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="104" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="105" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="106" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="107" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="108" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="109" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="110" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="111" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="112" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="113" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="114" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="115" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="116" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="117" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="118" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="119" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="120" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="121" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="122" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="123" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="124" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="125" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="126" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="127" iRefLayer="0" iRegion="0"/>
     <LogicRegion iRegion="5">
       <Layer iFirstInput="0" iLayer="0" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="6"/>
@@ -1337,18 +1337,133 @@
     <RefLayer iGlobalPhiStart="-782" iRefLayer="6"/>
     <RefLayer iGlobalPhiStart="-821" iRefLayer="7"/>
     <RefHit iInput="0" iPhiMax="-312" iPhiMin="-424" iRefHit="0" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-399" iPhiMin="-511" iRefHit="1" iRefLayer="1" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-352" iPhiMin="-464" iRefHit="2" iRefLayer="2" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-279" iPhiMin="-391" iRefHit="3" iRefLayer="3" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-279" iPhiMin="-391" iRefHit="4" iRefLayer="3" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-280" iPhiMin="-392" iRefHit="5" iRefLayer="4" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-280" iPhiMin="-392" iRefHit="6" iRefLayer="4" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-321" iPhiMin="-433" iRefHit="7" iRefLayer="5" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-321" iPhiMin="-433" iRefHit="8" iRefLayer="5" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-319" iPhiMin="-431" iRefHit="9" iRefLayer="6" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-319" iPhiMin="-431" iRefHit="10" iRefLayer="6" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="-358" iPhiMin="-470" iRefHit="11" iRefLayer="7" iRegion="0"/>
-    <RefHit iInput="1" iPhiMax="-358" iPhiMin="-470" iRefHit="12" iRefLayer="7" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-312" iPhiMin="-424" iRefHit="1" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-199" iPhiMin="-311" iRefHit="2" iRefLayer="0" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-199" iPhiMin="-311" iRefHit="3" iRefLayer="0" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-86" iPhiMin="-198" iRefHit="4" iRefLayer="0" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-86" iPhiMin="-198" iRefHit="5" iRefLayer="0" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="27" iPhiMin="-85" iRefHit="6" iRefLayer="0" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="27" iPhiMin="-85" iRefHit="7" iRefLayer="0" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="140" iPhiMin="28" iRefHit="8" iRefLayer="0" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="140" iPhiMin="28" iRefHit="9" iRefLayer="0" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="253" iPhiMin="141" iRefHit="10" iRefLayer="0" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="253" iPhiMin="141" iRefHit="11" iRefLayer="0" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-399" iPhiMin="-511" iRefHit="12" iRefLayer="1" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-399" iPhiMin="-511" iRefHit="13" iRefLayer="1" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-286" iPhiMin="-398" iRefHit="14" iRefLayer="1" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-286" iPhiMin="-398" iRefHit="15" iRefLayer="1" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-173" iPhiMin="-285" iRefHit="16" iRefLayer="1" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-173" iPhiMin="-285" iRefHit="17" iRefLayer="1" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="-60" iPhiMin="-172" iRefHit="18" iRefLayer="1" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="-60" iPhiMin="-172" iRefHit="19" iRefLayer="1" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="53" iPhiMin="-59" iRefHit="20" iRefLayer="1" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="53" iPhiMin="-59" iRefHit="21" iRefLayer="1" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="166" iPhiMin="54" iRefHit="22" iRefLayer="1" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="166" iPhiMin="54" iRefHit="23" iRefLayer="1" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-352" iPhiMin="-464" iRefHit="24" iRefLayer="2" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-352" iPhiMin="-464" iRefHit="25" iRefLayer="2" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-239" iPhiMin="-351" iRefHit="26" iRefLayer="2" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-239" iPhiMin="-351" iRefHit="27" iRefLayer="2" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-126" iPhiMin="-238" iRefHit="28" iRefLayer="2" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-126" iPhiMin="-238" iRefHit="29" iRefLayer="2" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="-13" iPhiMin="-125" iRefHit="30" iRefLayer="2" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="-13" iPhiMin="-125" iRefHit="31" iRefLayer="2" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="100" iPhiMin="-12" iRefHit="32" iRefLayer="2" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="100" iPhiMin="-12" iRefHit="33" iRefLayer="2" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="213" iPhiMin="101" iRefHit="34" iRefLayer="2" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="213" iPhiMin="101" iRefHit="35" iRefLayer="2" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-279" iPhiMin="-391" iRefHit="36" iRefLayer="3" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-279" iPhiMin="-391" iRefHit="37" iRefLayer="3" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-166" iPhiMin="-278" iRefHit="38" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-166" iPhiMin="-278" iRefHit="39" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-166" iPhiMin="-278" iRefHit="40" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="3" iPhiMax="-166" iPhiMin="-278" iRefHit="41" iRefLayer="3" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-53" iPhiMin="-165" iRefHit="42" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="3" iPhiMax="-53" iPhiMin="-165" iRefHit="43" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="-53" iPhiMin="-165" iRefHit="44" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="5" iPhiMax="-53" iPhiMin="-165" iRefHit="45" iRefLayer="3" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="60" iPhiMin="-52" iRefHit="46" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="5" iPhiMax="60" iPhiMin="-52" iRefHit="47" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="60" iPhiMin="-52" iRefHit="48" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="7" iPhiMax="60" iPhiMin="-52" iRefHit="49" iRefLayer="3" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="173" iPhiMin="61" iRefHit="50" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="7" iPhiMax="173" iPhiMin="61" iRefHit="51" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="173" iPhiMin="61" iRefHit="52" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="9" iPhiMax="173" iPhiMin="61" iRefHit="53" iRefLayer="3" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="286" iPhiMin="174" iRefHit="54" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="9" iPhiMax="286" iPhiMin="174" iRefHit="55" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="10" iPhiMax="286" iPhiMin="174" iRefHit="56" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="11" iPhiMax="286" iPhiMin="174" iRefHit="57" iRefLayer="3" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-280" iPhiMin="-392" iRefHit="58" iRefLayer="4" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-280" iPhiMin="-392" iRefHit="59" iRefLayer="4" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-167" iPhiMin="-279" iRefHit="60" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-167" iPhiMin="-279" iRefHit="61" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-167" iPhiMin="-279" iRefHit="62" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="3" iPhiMax="-167" iPhiMin="-279" iRefHit="63" iRefLayer="4" iRegion="1"/>
+    <RefHit iInput="2" iPhiMax="-54" iPhiMin="-166" iRefHit="64" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="3" iPhiMax="-54" iPhiMin="-166" iRefHit="65" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="-54" iPhiMin="-166" iRefHit="66" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="5" iPhiMax="-54" iPhiMin="-166" iRefHit="67" iRefLayer="4" iRegion="2"/>
+    <RefHit iInput="4" iPhiMax="59" iPhiMin="-53" iRefHit="68" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="5" iPhiMax="59" iPhiMin="-53" iRefHit="69" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="59" iPhiMin="-53" iRefHit="70" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="7" iPhiMax="59" iPhiMin="-53" iRefHit="71" iRefLayer="4" iRegion="3"/>
+    <RefHit iInput="6" iPhiMax="172" iPhiMin="60" iRefHit="72" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="7" iPhiMax="172" iPhiMin="60" iRefHit="73" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="172" iPhiMin="60" iRefHit="74" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="9" iPhiMax="172" iPhiMin="60" iRefHit="75" iRefLayer="4" iRegion="4"/>
+    <RefHit iInput="8" iPhiMax="285" iPhiMin="173" iRefHit="76" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="9" iPhiMax="285" iPhiMin="173" iRefHit="77" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="10" iPhiMax="285" iPhiMin="173" iRefHit="78" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="11" iPhiMax="285" iPhiMin="173" iRefHit="79" iRefLayer="4" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-321" iPhiMin="-433" iRefHit="80" iRefLayer="5" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-321" iPhiMin="-433" iRefHit="81" iRefLayer="5" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-208" iPhiMin="-320" iRefHit="82" iRefLayer="5" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-208" iPhiMin="-320" iRefHit="83" iRefLayer="5" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-95" iPhiMin="-207" iRefHit="84" iRefLayer="5" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-95" iPhiMin="-207" iRefHit="85" iRefLayer="5" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="18" iPhiMin="-94" iRefHit="86" iRefLayer="5" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="18" iPhiMin="-94" iRefHit="87" iRefLayer="5" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="131" iPhiMin="19" iRefHit="88" iRefLayer="5" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="131" iPhiMin="19" iRefHit="89" iRefLayer="5" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="244" iPhiMin="132" iRefHit="90" iRefLayer="5" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="244" iPhiMin="132" iRefHit="91" iRefLayer="5" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-319" iPhiMin="-431" iRefHit="92" iRefLayer="6" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-319" iPhiMin="-431" iRefHit="93" iRefLayer="6" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-206" iPhiMin="-318" iRefHit="94" iRefLayer="6" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-206" iPhiMin="-318" iRefHit="95" iRefLayer="6" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-93" iPhiMin="-205" iRefHit="96" iRefLayer="6" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-93" iPhiMin="-205" iRefHit="97" iRefLayer="6" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="20" iPhiMin="-92" iRefHit="98" iRefLayer="6" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="20" iPhiMin="-92" iRefHit="99" iRefLayer="6" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="133" iPhiMin="21" iRefHit="100" iRefLayer="6" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="133" iPhiMin="21" iRefHit="101" iRefLayer="6" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="246" iPhiMin="134" iRefHit="102" iRefLayer="6" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="246" iPhiMin="134" iRefHit="103" iRefLayer="6" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="-358" iPhiMin="-470" iRefHit="104" iRefLayer="7" iRegion="0"/>
+    <RefHit iInput="1" iPhiMax="-358" iPhiMin="-470" iRefHit="105" iRefLayer="7" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="-245" iPhiMin="-357" iRefHit="106" iRefLayer="7" iRegion="1"/>
+    <RefHit iInput="1" iPhiMax="-245" iPhiMin="-357" iRefHit="107" iRefLayer="7" iRegion="1"/>
+    <RefHit iInput="0" iPhiMax="-132" iPhiMin="-244" iRefHit="108" iRefLayer="7" iRegion="2"/>
+    <RefHit iInput="1" iPhiMax="-132" iPhiMin="-244" iRefHit="109" iRefLayer="7" iRegion="2"/>
+    <RefHit iInput="2" iPhiMax="-19" iPhiMin="-131" iRefHit="110" iRefLayer="7" iRegion="3"/>
+    <RefHit iInput="3" iPhiMax="-19" iPhiMin="-131" iRefHit="111" iRefLayer="7" iRegion="3"/>
+    <RefHit iInput="2" iPhiMax="94" iPhiMin="-18" iRefHit="112" iRefLayer="7" iRegion="4"/>
+    <RefHit iInput="3" iPhiMax="94" iPhiMin="-18" iRefHit="113" iRefLayer="7" iRegion="4"/>
+    <RefHit iInput="2" iPhiMax="207" iPhiMin="95" iRefHit="114" iRefLayer="7" iRegion="5"/>
+    <RefHit iInput="3" iPhiMax="207" iPhiMin="95" iRefHit="115" iRefLayer="7" iRegion="5"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="116" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="117" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="118" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="119" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="120" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="121" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="122" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="123" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="124" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="125" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="126" iRefLayer="0" iRegion="0"/>
+    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="127" iRefLayer="0" iRegion="0"/>
     <LogicRegion iRegion="0">
       <Layer iFirstInput="0" iLayer="0" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="4"/>
@@ -1369,23 +1484,6 @@
       <Layer iFirstInput="0" iLayer="16" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="17" nInputs="4"/>
     </LogicRegion>
-    <RefHit iInput="0" iPhiMax="-199" iPhiMin="-311" iRefHit="13" iRefLayer="0" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-286" iPhiMin="-398" iRefHit="14" iRefLayer="1" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-239" iPhiMin="-351" iRefHit="15" iRefLayer="2" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-166" iPhiMin="-278" iRefHit="16" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-166" iPhiMin="-278" iRefHit="17" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="2" iPhiMax="-166" iPhiMin="-278" iRefHit="18" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="3" iPhiMax="-166" iPhiMin="-278" iRefHit="19" iRefLayer="3" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-167" iPhiMin="-279" iRefHit="20" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-167" iPhiMin="-279" iRefHit="21" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="2" iPhiMax="-167" iPhiMin="-279" iRefHit="22" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="3" iPhiMax="-167" iPhiMin="-279" iRefHit="23" iRefLayer="4" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-208" iPhiMin="-320" iRefHit="24" iRefLayer="5" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-208" iPhiMin="-320" iRefHit="25" iRefLayer="5" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-206" iPhiMin="-318" iRefHit="26" iRefLayer="6" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-206" iPhiMin="-318" iRefHit="27" iRefLayer="6" iRegion="1"/>
-    <RefHit iInput="0" iPhiMax="-245" iPhiMin="-357" iRefHit="28" iRefLayer="7" iRegion="1"/>
-    <RefHit iInput="1" iPhiMax="-245" iPhiMin="-357" iRefHit="29" iRefLayer="7" iRegion="1"/>
     <LogicRegion iRegion="1">
       <Layer iFirstInput="0" iLayer="0" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="4"/>
@@ -1406,23 +1504,6 @@
       <Layer iFirstInput="0" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="0" iPhiMax="-86" iPhiMin="-198" iRefHit="30" iRefLayer="0" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-173" iPhiMin="-285" iRefHit="31" iRefLayer="1" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-126" iPhiMin="-238" iRefHit="32" iRefLayer="2" iRegion="2"/>
-    <RefHit iInput="2" iPhiMax="-53" iPhiMin="-165" iRefHit="33" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="3" iPhiMax="-53" iPhiMin="-165" iRefHit="34" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="4" iPhiMax="-53" iPhiMin="-165" iRefHit="35" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="5" iPhiMax="-53" iPhiMin="-165" iRefHit="36" iRefLayer="3" iRegion="2"/>
-    <RefHit iInput="2" iPhiMax="-54" iPhiMin="-166" iRefHit="37" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="3" iPhiMax="-54" iPhiMin="-166" iRefHit="38" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="4" iPhiMax="-54" iPhiMin="-166" iRefHit="39" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="5" iPhiMax="-54" iPhiMin="-166" iRefHit="40" iRefLayer="4" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-95" iPhiMin="-207" iRefHit="41" iRefLayer="5" iRegion="2"/>
-    <RefHit iInput="1" iPhiMax="-95" iPhiMin="-207" iRefHit="42" iRefLayer="5" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-93" iPhiMin="-205" iRefHit="43" iRefLayer="6" iRegion="2"/>
-    <RefHit iInput="1" iPhiMax="-93" iPhiMin="-205" iRefHit="44" iRefLayer="6" iRegion="2"/>
-    <RefHit iInput="0" iPhiMax="-132" iPhiMin="-244" iRefHit="45" iRefLayer="7" iRegion="2"/>
-    <RefHit iInput="1" iPhiMax="-132" iPhiMin="-244" iRefHit="46" iRefLayer="7" iRegion="2"/>
     <LogicRegion iRegion="2">
       <Layer iFirstInput="0" iLayer="0" nInputs="4"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="4"/>
@@ -1443,23 +1524,6 @@
       <Layer iFirstInput="2" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="2" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="2" iPhiMax="27" iPhiMin="-85" iRefHit="47" iRefLayer="0" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="-60" iPhiMin="-172" iRefHit="48" iRefLayer="1" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="-13" iPhiMin="-125" iRefHit="49" iRefLayer="2" iRegion="3"/>
-    <RefHit iInput="4" iPhiMax="60" iPhiMin="-52" iRefHit="50" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="5" iPhiMax="60" iPhiMin="-52" iRefHit="51" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="6" iPhiMax="60" iPhiMin="-52" iRefHit="52" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="7" iPhiMax="60" iPhiMin="-52" iRefHit="53" iRefLayer="3" iRegion="3"/>
-    <RefHit iInput="4" iPhiMax="59" iPhiMin="-53" iRefHit="54" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="5" iPhiMax="59" iPhiMin="-53" iRefHit="55" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="6" iPhiMax="59" iPhiMin="-53" iRefHit="56" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="7" iPhiMax="59" iPhiMin="-53" iRefHit="57" iRefLayer="4" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="18" iPhiMin="-94" iRefHit="58" iRefLayer="5" iRegion="3"/>
-    <RefHit iInput="3" iPhiMax="18" iPhiMin="-94" iRefHit="59" iRefLayer="5" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="20" iPhiMin="-92" iRefHit="60" iRefLayer="6" iRegion="3"/>
-    <RefHit iInput="3" iPhiMax="20" iPhiMin="-92" iRefHit="61" iRefLayer="6" iRegion="3"/>
-    <RefHit iInput="2" iPhiMax="-19" iPhiMin="-131" iRefHit="62" iRefLayer="7" iRegion="3"/>
-    <RefHit iInput="3" iPhiMax="-19" iPhiMin="-131" iRefHit="63" iRefLayer="7" iRegion="3"/>
     <LogicRegion iRegion="3">
       <Layer iFirstInput="0" iLayer="0" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="6"/>
@@ -1480,23 +1544,6 @@
       <Layer iFirstInput="4" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="4" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="2" iPhiMax="140" iPhiMin="28" iRefHit="64" iRefLayer="0" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="53" iPhiMin="-59" iRefHit="65" iRefLayer="1" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="100" iPhiMin="-12" iRefHit="66" iRefLayer="2" iRegion="4"/>
-    <RefHit iInput="6" iPhiMax="173" iPhiMin="61" iRefHit="67" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="7" iPhiMax="173" iPhiMin="61" iRefHit="68" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="8" iPhiMax="173" iPhiMin="61" iRefHit="69" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="9" iPhiMax="173" iPhiMin="61" iRefHit="70" iRefLayer="3" iRegion="4"/>
-    <RefHit iInput="6" iPhiMax="172" iPhiMin="60" iRefHit="71" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="7" iPhiMax="172" iPhiMin="60" iRefHit="72" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="8" iPhiMax="172" iPhiMin="60" iRefHit="73" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="9" iPhiMax="172" iPhiMin="60" iRefHit="74" iRefLayer="4" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="131" iPhiMin="19" iRefHit="75" iRefLayer="5" iRegion="4"/>
-    <RefHit iInput="3" iPhiMax="131" iPhiMin="19" iRefHit="76" iRefLayer="5" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="133" iPhiMin="21" iRefHit="77" iRefLayer="6" iRegion="4"/>
-    <RefHit iInput="3" iPhiMax="133" iPhiMin="21" iRefHit="78" iRefLayer="6" iRegion="4"/>
-    <RefHit iInput="2" iPhiMax="94" iPhiMin="-18" iRefHit="79" iRefLayer="7" iRegion="4"/>
-    <RefHit iInput="3" iPhiMax="94" iPhiMin="-18" iRefHit="80" iRefLayer="7" iRegion="4"/>
     <LogicRegion iRegion="4">
       <Layer iFirstInput="0" iLayer="0" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="6"/>
@@ -1517,53 +1564,6 @@
       <Layer iFirstInput="6" iLayer="16" nInputs="6"/>
       <Layer iFirstInput="6" iLayer="17" nInputs="6"/>
     </LogicRegion>
-    <RefHit iInput="2" iPhiMax="253" iPhiMin="141" iRefHit="81" iRefLayer="0" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="166" iPhiMin="54" iRefHit="82" iRefLayer="1" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="213" iPhiMin="101" iRefHit="83" iRefLayer="2" iRegion="5"/>
-    <RefHit iInput="8" iPhiMax="286" iPhiMin="174" iRefHit="84" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="9" iPhiMax="286" iPhiMin="174" iRefHit="85" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="10" iPhiMax="286" iPhiMin="174" iRefHit="86" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="11" iPhiMax="286" iPhiMin="174" iRefHit="87" iRefLayer="3" iRegion="5"/>
-    <RefHit iInput="8" iPhiMax="285" iPhiMin="173" iRefHit="88" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="9" iPhiMax="285" iPhiMin="173" iRefHit="89" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="10" iPhiMax="285" iPhiMin="173" iRefHit="90" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="11" iPhiMax="285" iPhiMin="173" iRefHit="91" iRefLayer="4" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="244" iPhiMin="132" iRefHit="92" iRefLayer="5" iRegion="5"/>
-    <RefHit iInput="3" iPhiMax="244" iPhiMin="132" iRefHit="93" iRefLayer="5" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="246" iPhiMin="134" iRefHit="94" iRefLayer="6" iRegion="5"/>
-    <RefHit iInput="3" iPhiMax="246" iPhiMin="134" iRefHit="95" iRefLayer="6" iRegion="5"/>
-    <RefHit iInput="2" iPhiMax="207" iPhiMin="95" iRefHit="96" iRefLayer="7" iRegion="5"/>
-    <RefHit iInput="3" iPhiMax="207" iPhiMin="95" iRefHit="97" iRefLayer="7" iRegion="5"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="98" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="99" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="100" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="101" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="102" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="103" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="104" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="105" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="106" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="107" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="108" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="109" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="110" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="111" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="112" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="113" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="114" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="115" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="116" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="117" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="118" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="119" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="120" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="121" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="122" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="123" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="124" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="125" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="126" iRefLayer="0" iRegion="0"/>
-    <RefHit iInput="0" iPhiMax="1" iPhiMin="0" iRefHit="127" iRefLayer="0" iRegion="0"/>
     <LogicRegion iRegion="5">
       <Layer iFirstInput="0" iLayer="0" nInputs="6"/>
       <Layer iFirstInput="0" iLayer="1" nInputs="6"/>

--- a/interface/InternalObj.h
+++ b/interface/InternalObj.h
@@ -10,8 +10,20 @@ struct InternalObj{
   int   bx, q, charge;
   int refLayer;
 
-  InternalObj() : pt(-1.),eta(99.),phi(99.),disc(-999), bx(0),q(-1), charge(99), refLayer(-1) {}
+  InternalObj() : pt(-1.), eta(99.), phi(9999.), disc(-999), bx(0), q(-1), charge(99), refLayer(-1) {}
+  InternalObj(float pt, float eta, float phi, 
+	      float disc=-999, int bx=0, int q=-1, 
+	      int charge=99, int refLayer=-1) :
+  pt(pt), eta(eta), phi(phi), disc(disc), bx(bx), q(q), charge(charge), refLayer(refLayer) {}
+
   bool isValid() const { return q >= 0;}
+
+  bool operator< (const InternalObj & o) const { 
+    if(q > o.q) return true;
+    else if(q==o.q && disc > o.disc) return true;
+    else return false;
+
+  }
 
   friend std::ostream & operator<< (std::ostream &out, const InternalObj &o);
 

--- a/interface/OMTFConfiguration.h
+++ b/interface/OMTFConfiguration.h
@@ -42,6 +42,8 @@ class RefHitDef{
   ///Hit has to fit into this range to be assigned to this iRegion;
   std::pair<int, int> range;
 
+  friend std::ostream & operator << (std::ostream &out, const RefHitDef & aRefHitDef);
+
 };
 
 class OMTFConfiguration{

--- a/interface/OMTFProcessor.h
+++ b/interface/OMTFProcessor.h
@@ -84,7 +84,8 @@ class OMTFProcessor{
   std::map<Key,GoldenPattern*> theGPs;
 
   ///Map holding results on current event data
-  ///for each GP
+  ///for each GP. 
+  ///Reference hit number is isued as a vector index.
   std::vector<OMTFProcessor::resultsMap> myResults;
 
 };

--- a/interface/OMTFResult.h
+++ b/interface/OMTFResult.h
@@ -31,6 +31,8 @@ class OMTFResult{
 
   void clear();
 
+  bool empty() const;
+
   friend std::ostream & operator << (std::ostream &out, const OMTFResult & aResult);
 
  private:

--- a/interface/OMTFSorter.h
+++ b/interface/OMTFSorter.h
@@ -17,15 +17,23 @@ class OMTFSorter{
   ///Sort all processor results. 
   ///First for each region cone find a best candidate using sortRegionResults() 
   ///Then select best candidate amongs found for each logic region.
-  ///The sorthing is made for candidates with a given charge
+  ///The sorting is made for candidates with a given charge
   InternalObj sortProcessorResults(const std::vector<OMTFProcessor::resultsMap> & procResults,
 				   int charge);
+  //
+  void sortProcessorResults(const std::vector<OMTFProcessor::resultsMap> & procResults,
+			    std::vector<InternalObj> & refHitCleanCands,
+			    int charge);
 
   ///Sort all processor results. 
   ///First for each region cone find a best candidate using sortRegionResults() 
   ///Then select best candidate amongs found for each logic region
   L1MuRegionalCand sortProcessor(const std::vector<OMTFProcessor::resultsMap> & procResults,
 				 int charge);
+  //
+  void sortProcessor(const std::vector<OMTFProcessor::resultsMap> & procResults,
+		     std::vector<L1MuRegionalCand> & sortedCands,
+		     int charge);
 
   ///Sort results from a single reference hit.
   ///Select candidate with highest number of hit layers

--- a/interface/OMTFSorter.h
+++ b/interface/OMTFSorter.h
@@ -19,28 +19,28 @@ class OMTFSorter{
   ///Then select best candidate amongs found for each logic region.
   ///The sorting is made for candidates with a given charge
   InternalObj sortProcessorResults(const std::vector<OMTFProcessor::resultsMap> & procResults,
-				   int charge);
+				   int charge=0);
   //
   void sortProcessorResults(const std::vector<OMTFProcessor::resultsMap> & procResults,
 			    std::vector<InternalObj> & refHitCleanCands,
-			    int charge);
+			    int charge=0);
 
   ///Sort all processor results. 
   ///First for each region cone find a best candidate using sortRegionResults() 
   ///Then select best candidate amongs found for each logic region
   L1MuRegionalCand sortProcessor(const std::vector<OMTFProcessor::resultsMap> & procResults,
-				 int charge);
+				 int charge=0);
   //
   void sortProcessor(const std::vector<OMTFProcessor::resultsMap> & procResults,
 		     std::vector<L1MuRegionalCand> & sortedCands,
-		     int charge);
+		     int charge=0);
 
   ///Sort results from a single reference hit.
   ///Select candidate with highest number of hit layers
   ///Then select a candidate with largest likelihood value and given charge
   ///as we allow two candidates with opposite charge from single 10deg region
   InternalObj sortRefHitResults(const OMTFProcessor::resultsMap & aResultsMap, 
-				int charge);
+				int charge=0);
 
  private:
 

--- a/interface/OMTFSorter.h
+++ b/interface/OMTFSorter.h
@@ -27,11 +27,11 @@ class OMTFSorter{
   L1MuRegionalCand sortProcessor(const std::vector<OMTFProcessor::resultsMap> & procResults,
 				 int charge);
 
-  ///Sort results for signle logic region.
-  ///Select candidate with highed number of hit layers
+  ///Sort results from a single reference hit.
+  ///Select candidate with highest number of hit layers
   ///Then select a candidate with largest likelihood value and given charge
   ///as we allow two candidates with opposite charge from single 10deg region
-  InternalObj sortRegionResults(const OMTFProcessor::resultsMap & aResultsMap, 
+  InternalObj sortRefHitResults(const OMTFProcessor::resultsMap & aResultsMap, 
 				int charge);
 
  private:

--- a/plugins/OMTFProducer.cc
+++ b/plugins/OMTFProducer.cc
@@ -133,30 +133,40 @@ void OMTFProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSetup){
     const std::vector<OMTFProcessor::resultsMap> & myResults = myOMTF->processInput(iProcessor,myShiftedInput);
 
     ///At the moment allow up to two, opposite charge, candidates per processor.    
-    L1MuRegionalCand myOTFCandidatePlus = mySorter->sortProcessor(myResults,1);
+    //L1MuRegionalCand myOTFCandidatePlus = mySorter->sortProcessor(myResults,1);
     //L1MuRegionalCand myOTFCandidateMinus = mySorter->sortProcessor(myResults,-1);
+    //At the moment allow one candidate pre processor ignoring its charge
+    L1MuRegionalCand myOTFCandidate = mySorter->sortProcessor(myResults,0);
 
     ////Switch from internal processor 10bit scale to global one
     int procOffset = OMTFConfiguration::globalPhiStart(iProcessor);
     if(procOffset<0) procOffset+=OMTFConfiguration::nPhiBins;
 
-    float phiValue = (myOTFCandidatePlus.phiValue()+OMTFConfiguration::globalPhiStart(iProcessor)+511)/OMTFConfiguration::nPhiBins*2*M_PI;
-    if(phiValue>M_PI) phiValue-=2*M_PI;
-    myOTFCandidatePlus.setPhiValue(phiValue);
+    float phiValue; 
+    //phiValue = (myOTFCandidatePlus.phiValue()+OMTFConfiguration::globalPhiStart(iProcessor)+511)/OMTFConfiguration::nPhiBins*2*M_PI;
+    //if(phiValue>M_PI) phiValue-=2*M_PI;
+    //myOTFCandidatePlus.setPhiValue(phiValue);
 
     //phiValue = (myOTFCandidateMinus.phiValue()+OMTFConfiguration::globalPhiStart(iProcessor)+511)/OMTFConfiguration::nPhiBins*2*M_PI;
     //if(phiValue>M_PI) phiValue-=2*M_PI;
     //myOTFCandidateMinus.setPhiValue(phiValue);
+
+    phiValue = (myOTFCandidate.phiValue()+OMTFConfiguration::globalPhiStart(iProcessor)+511)/OMTFConfiguration::nPhiBins*2*M_PI;
+    if(phiValue>M_PI) phiValue-=2*M_PI;
+    myOTFCandidate.setPhiValue(phiValue);
+
     //////////////////
-    if(myOTFCandidatePlus.pt_packed()) myCands->push_back(myOTFCandidatePlus); 
+    //if(myOTFCandidatePlus.pt_packed()) myCands->push_back(myOTFCandidatePlus); 
     //if(myOTFCandidateMinus.pt_packed()) myCands->push_back(myOTFCandidateMinus); 
-   
+    if(myOTFCandidate.pt_packed()) myCands->push_back(myOTFCandidate); 
+
     ///Write to XML
     if(dumpResultToXML){
       xercesc::DOMElement * aProcElement = myWriter->writeEventData(aTopElement,iProcessor,myShiftedInput);
       for(unsigned int iRefHit=0;iRefHit<OMTFConfiguration::nTestRefHits;++iRefHit){
 	///Dump only regions, where a candidate was found
-	InternalObj myCand = mySorter->sortRefHitResults(myResults[iRefHit],1);
+	//InternalObj myCand = mySorter->sortRefHitResults(myResults[iRefHit],1);
+	InternalObj myCand = mySorter->sortRefHitResults(myResults[iRefHit],0);//charge=0 means ignore charge
 	if(myCand.pt){
 	  myWriter->writeCandidateData(aProcElement,iRefHit,myCand);
 	  for(auto & itKey: myResults[iRefHit]) myWriter->writeResultsData(aProcElement, 

--- a/plugins/OMTFProducer.cc
+++ b/plugins/OMTFProducer.cc
@@ -134,7 +134,7 @@ void OMTFProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSetup){
 
     ///At the moment allow up to two, opposite charge, candidates per processor.    
     L1MuRegionalCand myOTFCandidatePlus = mySorter->sortProcessor(myResults,1);
-    L1MuRegionalCand myOTFCandidateMinus = mySorter->sortProcessor(myResults,-1);
+    //L1MuRegionalCand myOTFCandidateMinus = mySorter->sortProcessor(myResults,-1);
 
     ////Switch from internal processor 10bit scale to global one
     int procOffset = OMTFConfiguration::globalPhiStart(iProcessor);
@@ -144,9 +144,9 @@ void OMTFProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSetup){
     if(phiValue>M_PI) phiValue-=2*M_PI;
     myOTFCandidatePlus.setPhiValue(phiValue);
 
-    phiValue = (myOTFCandidateMinus.phiValue()+OMTFConfiguration::globalPhiStart(iProcessor)+511)/OMTFConfiguration::nPhiBins*2*M_PI;
-    if(phiValue>M_PI) phiValue-=2*M_PI;
-    myOTFCandidateMinus.setPhiValue(phiValue);
+    //phiValue = (myOTFCandidateMinus.phiValue()+OMTFConfiguration::globalPhiStart(iProcessor)+511)/OMTFConfiguration::nPhiBins*2*M_PI;
+    //if(phiValue>M_PI) phiValue-=2*M_PI;
+    //myOTFCandidateMinus.setPhiValue(phiValue);
     //////////////////
     if(myOTFCandidatePlus.pt_packed()) myCands->push_back(myOTFCandidatePlus); 
     //if(myOTFCandidateMinus.pt_packed()) myCands->push_back(myOTFCandidateMinus); 
@@ -154,13 +154,13 @@ void OMTFProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSetup){
     ///Write to XML
     if(dumpResultToXML){
       xercesc::DOMElement * aProcElement = myWriter->writeEventData(aTopElement,iProcessor,myShiftedInput);
-      for(unsigned int iRegion=0;iRegion<6;++iRegion){
+      for(unsigned int iRefHit=0;iRefHit<OMTFConfiguration::nTestRefHits;++iRefHit){
 	///Dump only regions, where a candidate was found
-	InternalObj myCand = mySorter->sortRegionResults(myResults[iRegion],1);
+	InternalObj myCand = mySorter->sortRefHitResults(myResults[iRefHit],1);
 	if(myCand.pt){
-	  myWriter->writeCandidateData(aProcElement,iRegion,myCand);
-	  for(auto & itKey: myResults[iRegion]) myWriter->writeResultsData(aProcElement, 
-									   iRegion,
+	  myWriter->writeCandidateData(aProcElement,iRefHit,myCand);
+	  for(auto & itKey: myResults[iRefHit]) myWriter->writeResultsData(aProcElement, 
+									   iRefHit,
 									   itKey.first,itKey.second);    
 	}
       }

--- a/src/InternalObj.cc
+++ b/src/InternalObj.cc
@@ -3,7 +3,7 @@
 std::ostream & operator<< (std::ostream &out, const InternalObj &o){
   out<<"InternalObj: ";
   out <<" pt: "<<o.pt<<", eta: "<<o.eta<<", phi: "<<o.phi
-      <<", q: "<<o.q<<", bx: "<<o.bx
+      <<", q: "<<o.q<<", bx: "<<o.bx<<", charge: "<<o.charge
       <<", disc: "<<o.disc<<" refLayer: "<<o.refLayer;
   
   return out;

--- a/src/OMTFConfigMaker.cc
+++ b/src/OMTFConfigMaker.cc
@@ -92,6 +92,10 @@ void OMTFConfigMaker::makeConnetionsMap(unsigned int iProcessor,
 	  if(iRegion>5) continue;
 	  fillInputRange(iProcessor,iRegion,aInput);
 	  fillInputRange(iProcessor,iRegion,iRefLayer,iInput);
+	  ///Always use two hits from a single chamber. 
+	  ///As we use single muons, the second hit has
+	  ///to be added by hand.
+	  if(iInput%2==0) fillInputRange(iProcessor,iRegion,iRefLayer,iInput+1);
       }
     }      
   }

--- a/src/OMTFConfiguration.cc
+++ b/src/OMTFConfiguration.cc
@@ -55,6 +55,19 @@ bool RefHitDef::fitsRange(int iPhi) const{
 }
 ///////////////////////////////////////////////
 ///////////////////////////////////////////////
+std::ostream & operator << (std::ostream &out, const  RefHitDef & aRefHitDef){
+
+
+  out<<"iRefLayer: "<<aRefHitDef.iRefLayer
+     <<" iInput: "<<aRefHitDef.iInput
+     <<" iRegion: "<<aRefHitDef.iRegion
+     <<" range: ("<<aRefHitDef.range.first
+     <<", "<<aRefHitDef.range.second<<std::endl;
+
+  return out;
+}
+///////////////////////////////////////////////
+///////////////////////////////////////////////
 OMTFConfiguration::OMTFConfiguration(const edm::ParameterSet & theConfig){
 
   if (!theConfig.exists("configXMLFile") ) return;

--- a/src/OMTFProcessor.cc
+++ b/src/OMTFProcessor.cc
@@ -20,7 +20,8 @@
 ///////////////////////////////////////////////
 OMTFProcessor::OMTFProcessor(const edm::ParameterSet & theConfig){
 
-myResults.assign(6,OMTFProcessor::resultsMap());
+
+  myResults.assign(OMTFConfiguration::nTestRefHits,OMTFProcessor::resultsMap());
 
   if ( !theConfig.exists("patternsXMLFiles") ) return;
   std::vector<std::string> fileNames = theConfig.getParameter<std::vector<std::string> >("patternsXMLFiles");
@@ -47,7 +48,7 @@ bool OMTFProcessor::configure(XMLConfigReader *aReader){
     if(!addGP(it)) return false;
   }
 
-  averagePatterns();
+  //averagePatterns();
 
   return true;
 }
@@ -124,26 +125,29 @@ const std::vector<OMTFProcessor::resultsMap> & OMTFProcessor::processInput(unsig
 	GoldenPattern::layerResult aLayerResult = itGP.second->process1Layer1RefLayer(aRefHitDef.iRefLayer,iLayer,
 										      phiRef,
 										      restrictedLayerHits);
-	myResults[iRegion][itGP.second->key()].addResult(aRefHitDef.iRefLayer,iLayer,aLayerResult.first,phiRef);	 
+	myResults[OMTFConfiguration::nTestRefHits-nTestedRefHits-1][itGP.second->key()].addResult(aRefHitDef.iRefLayer,iLayer,aLayerResult.first,phiRef);	 
       }
     }
   }  
   //////////////////////////////////////
   ////////////////////////////////////// 
-  for(auto & itRegion: myResults) for(auto & itKey: itRegion) itKey.second.finalise();
+  for(auto & itRefHit: myResults) for(auto & itKey: itRefHit) itKey.second.finalise();
 
   //#ifndef NDEBUG
   std::ostringstream myStr;
   myStr<<"iProcessor: "<<iProcessor<<std::endl;
   myStr<<"Input: ------------"<<std::endl;
   myStr<<aInput<<std::endl;
-  /*
-  for(auto itRegion: myResults){ 
-    for(auto itKey: itRegion){      
+  
+  for(auto itRefHit: myResults){
+    myStr<<"--- Reference hit ---"<<std::endl;
+    for(auto itKey: itRefHit){      
+      if(itKey.second.empty()) continue;
       myStr<<itKey.first<<std::endl;
       myStr<<itKey.second<<std::endl;
     }
-  }*/
+    myStr<<"--------------------"<<std::endl;
+  }
   //LogDebug("OMTF processor")<<myStr.str();
   edm::LogInfo("OMTF processor")<<myStr.str();
   //#endif

--- a/src/OMTFProcessor.cc
+++ b/src/OMTFProcessor.cc
@@ -79,13 +79,14 @@ void  OMTFProcessor::averagePatterns(){
     
     GoldenPattern::vector2D meanDistPhi1  = aGP1->getMeanDistPhi();
     GoldenPattern::vector2D meanDistPhi2  = aGP2->getMeanDistPhi();
-    
-    for(unsigned int iLayer=0;OMTFConfiguration::nLayers;++iLayer){
-      for(unsigned int iRefLayer=0;OMTFConfiguration::nRefLayers;++iRefLayer){
+
+    for(unsigned int iLayer=0;iLayer<OMTFConfiguration::nLayers;++iLayer){
+      for(unsigned int iRefLayer=0;iRefLayer<OMTFConfiguration::nRefLayers;++iRefLayer){
 	meanDistPhi1[iLayer][iRefLayer]+=meanDistPhi2[iLayer][iRefLayer];
 	meanDistPhi1[iLayer][iRefLayer]/=2;
       }
     }
+
     aGP1->setMeanDistPhi(meanDistPhi1);
     aGP2->setMeanDistPhi(meanDistPhi1);
   }

--- a/src/OMTFProcessor.cc
+++ b/src/OMTFProcessor.cc
@@ -55,6 +55,10 @@ bool OMTFProcessor::configure(XMLConfigReader *aReader){
 ///////////////////////////////////////////////
 bool OMTFProcessor::addGP(GoldenPattern *aGP){
 
+  //if(aGP->key().thePtCode<14 && aGP->key().thePtCode%2==1) return true;
+  //if(aGP->key().thePtCode>18 && aGP->key().thePtCode%2==1) return true;
+  //if(aGP->key().thePtCode%2==1) return true;
+
   if(theGPs.find(aGP->key())!=theGPs.end()) return false;
   else theGPs[aGP->key()] = new GoldenPattern(*aGP);
 

--- a/src/OMTFResult.cc
+++ b/src/OMTFResult.cc
@@ -50,6 +50,17 @@ void OMTFResult::finalise(){
 }
 ////////////////////////////////////////////
 ////////////////////////////////////////////
+bool OMTFResult::empty() const{
+
+  unsigned int nHits = 0;
+
+  for(unsigned int iRefLayer=0;iRefLayer<OMTFConfiguration::nRefLayers;++iRefLayer){
+    nHits+=hits1D[iRefLayer];
+  }      
+  return (nHits==0);
+}
+////////////////////////////////////////////
+////////////////////////////////////////////
 std::ostream & operator << (std::ostream &out, const OMTFResult & aResult){
 
  for(unsigned int iLogicLayer=0;iLogicLayer<aResult.results.size();++iLogicLayer){

--- a/src/OMTFSorter.cc
+++ b/src/OMTFSorter.cc
@@ -55,7 +55,7 @@ std::tuple<unsigned int,unsigned int, int, int> OMTFSorter::sortSingleResult(con
 }
 ///////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////
-InternalObj OMTFSorter::sortRegionResults(const OMTFProcessor::resultsMap & aResultsMap,
+InternalObj OMTFSorter::sortRefHitResults(const OMTFProcessor::resultsMap & aResultsMap,
 					  int charge){
 
   unsigned int pdfValMax = 0;
@@ -97,6 +97,7 @@ InternalObj OMTFSorter::sortRegionResults(const OMTFProcessor::resultsMap & aRes
   candidate.refLayer = refLayer;
 
   /////TEST AVERAGE PT///////
+  /*
   pdfValMax = 0;
   for(auto itKey: aResultsMap){
     if(itKey.first.thePtCode>candidate.pt) continue;
@@ -137,8 +138,6 @@ InternalObj OMTFSorter::sortRegionResults(const OMTFProcessor::resultsMap & aRes
   candidateNext.disc = pdfValMax;
   candidateNext.refLayer = refLayer;
 
-
-
   if(candidate.pt){
     float weightedPtCode = candidatePrevious.pt*candidatePrevious.disc + 
                            candidate.pt*candidate.disc + 
@@ -146,6 +145,7 @@ InternalObj OMTFSorter::sortRegionResults(const OMTFProcessor::resultsMap & aRes
     weightedPtCode/= candidatePrevious.disc + candidate.disc + candidateNext.disc;
     candidate.pt = (int)weightedPtCode;
   } 
+*/
   ////////////////////////////// 
 
   return candidate;
@@ -157,17 +157,19 @@ InternalObj OMTFSorter::sortProcessorResults(const std::vector<OMTFProcessor::re
 					     int charge){
 
   InternalObj candidate;
-  std::vector<InternalObj> regionCands;
+  std::vector<InternalObj> refHitCands;
 
-  for(auto itRegion: procResults) regionCands.push_back(sortRegionResults(itRegion,charge));
+  for(auto itRefHit: procResults) refHitCands.push_back(sortRefHitResults(itRefHit,charge));
 
-  for(auto itCand: regionCands){
+  for(auto itCand: refHitCands){
     if(itCand.q>candidate.q) candidate = itCand;
     else if(itCand.q==candidate.q && itCand.disc>candidate.disc) candidate = itCand;
   }
 
   std::ostringstream myStr;
-  for(unsigned int iRegion=0;iRegion<regionCands.size();++iRegion) myStr<<"Logic Region: "<<iRegion<<" "<<regionCands[iRegion]<<std::endl;
+  for(unsigned int iRefHit=0;iRefHit<refHitCands.size();++iRefHit){
+    if(refHitCands[iRefHit].q) myStr<<"Ref hit: "<<iRefHit<<" "<<refHitCands[iRefHit]<<std::endl;
+  }
   myStr<<"Selected Candidate with charge: "<<charge<<" "<<candidate<<std::endl;
   edm::LogInfo("OMTF Sorter")<<myStr.str();
 

--- a/src/OMTFSorter.cc
+++ b/src/OMTFSorter.cc
@@ -163,7 +163,7 @@ InternalObj OMTFSorter::sortProcessorResults(const std::vector<OMTFProcessor::re
 
   for(auto itCand: regionCands){
     if(itCand.q>candidate.q) candidate = itCand;
-    if(itCand.q==candidate.q && itCand.disc>candidate.disc) candidate = itCand;
+    else if(itCand.q==candidate.q && itCand.disc>candidate.disc) candidate = itCand;
   }
 
   std::ostringstream myStr;

--- a/src/OMTFSorter.cc
+++ b/src/OMTFSorter.cc
@@ -151,30 +151,36 @@ InternalObj OMTFSorter::sortRefHitResults(const OMTFProcessor::resultsMap & aRes
 ///////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////
 InternalObj OMTFSorter::sortProcessorResults(const std::vector<OMTFProcessor::resultsMap> & procResults,
-					     int charge){
+					     int charge){ //method kept for backward compatibility
 
-  InternalObj candidate;
+  std::vector<InternalObj> sortedCandidates;
+  sortProcessorResults(procResults, sortedCandidates, charge);
+
+  InternalObj candidate = sortedCandidates.size()>0 ? sortedCandidates[0] : InternalObj() ; 
+  std::ostringstream myStr;
+  myStr<<"Selected Candidate with charge: "<<charge<<" "<<candidate<<std::endl;
+  edm::LogInfo("OMTF Sorter")<<myStr.str();
+
+  return candidate;
+
+}
+///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////
+void OMTFSorter::sortProcessorResults(const std::vector<OMTFProcessor::resultsMap> & procResults,
+				      std::vector<InternalObj> & refHitCleanCands,
+				      int charge){
+
+  refHitCleanCands.clear();
   std::vector<InternalObj> refHitCands;
 
   for(auto itRefHit: procResults) refHitCands.push_back(sortRefHitResults(itRefHit,charge));
 
-  // Sort candidates with decreased goodness...
-  /*
-  std::sort( refHitCands.begin(), refHitCands.end(), 
-	     [](const InternalObj &o1, const InternalObj &o2){
-	       if(o1.q > o2.q) return true;
-	       else if(o1.q==o2.q && o1.disc > o2.disc) return true;
-	       else return false;
-	     } );
-  */
-  //where goodness definied in < operator of InternalObj
+  // Sort candidates with decreased goodness,
+  // where goodness definied in < operator of InternalObj
   std::sort( refHitCands.begin(), refHitCands.end() );
-  // and then take the best one
-  if(!refHitCands.empty()) candidate = refHitCands[0];
 
-  //Clean candidate list by removing dupicates bazing on Phi distance 
-  //Assumed that list is ordered
-  std::vector<InternalObj> refHitCleanCands;
+  // Clean candidate list by removing dupicates bazing on Phi distance. 
+  // Assumed that the list is ordered
   for(std::vector<InternalObj>::iterator it1 = refHitCands.begin();
       it1 != refHitCands.end(); ++it1){
     bool isGhost=false;
@@ -185,11 +191,11 @@ InternalObj OMTFSorter::sortProcessorResults(const std::vector<OMTFProcessor::re
 	break;
       }
     }
-    if(!isGhost) refHitCleanCands.push_back(*it1);
+    if(it1->q>0 && !isGhost) refHitCleanCands.push_back(*it1);
   }
-  refHitCleanCands.resize( refHitCands.size() );//preserve number of candidates adding empty ones
+  refHitCleanCands.resize( refHitCands.size() );//preserve original number of candidates adding empty ones
 
-  //if(candidate.q>0){
+  //if(refHitCands.size()>0 && refHitCands[0].q>0){
   if(true){
     std::cout<<"before cleaning\n";
     for(unsigned int ii=0; ii<refHitCands.size(); ++ii)
@@ -204,16 +210,19 @@ InternalObj OMTFSorter::sortProcessorResults(const std::vector<OMTFProcessor::re
   for(unsigned int iRefHit=0;iRefHit<refHitCands.size();++iRefHit){
     if(refHitCands[iRefHit].q) myStr<<"Ref hit: "<<iRefHit<<" "<<refHitCands[iRefHit]<<std::endl;
   }
-  myStr<<"Selected Candidate with charge: "<<charge<<" "<<candidate<<std::endl;
+  myStr<<"Selected Candidates with charge: "<<charge<<std::endl;
+  for(unsigned int iCand=0; iCand<refHitCleanCands.size(); ++iCand){
+    myStr<<"Cand: "<<iCand<<" "<<refHitCleanCands[iCand]<<std::endl;
+  }
   edm::LogInfo("OMTF Sorter")<<myStr.str();
 
 
-  return candidate;
+  return;
 }
 ///////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////
 L1MuRegionalCand OMTFSorter::sortProcessor(const std::vector<OMTFProcessor::resultsMap> & procResults,
-					   int charge){
+					   int charge){ //method kept for backward compatibility
 
   InternalObj myCand = sortProcessorResults(procResults, charge);
 
@@ -228,3 +237,26 @@ L1MuRegionalCand OMTFSorter::sortProcessor(const std::vector<OMTFProcessor::resu
 }
 ///////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////
+void OMTFSorter::sortProcessor(const std::vector<OMTFProcessor::resultsMap> & procResults,
+			       std::vector<L1MuRegionalCand> & sortedCands,
+			       int charge){
+
+  sortedCands.clear();
+  std::vector<InternalObj> mySortedCands;
+  sortProcessorResults(procResults, mySortedCands, charge);
+
+  for(auto myCand: mySortedCands){
+    L1MuRegionalCand candidate;
+    candidate.setPhiValue(myCand.phi);
+    candidate.setPtPacked(myCand.pt);
+    //candidate.setQualityPacked(3);//FIX ME
+    candidate.setBx(1000*myCand.disc+100*myCand.refLayer+myCand.q);//FIX ME
+    candidate.setChargeValue(myCand.charge);
+    sortedCands.push_back(candidate);
+  }
+
+  return;
+}
+///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////
+

--- a/src/XMLConfigWriter.cc
+++ b/src/XMLConfigWriter.cc
@@ -329,13 +329,11 @@ void  XMLConfigWriter::writeConnectionsData(const std::vector<std::vector <OMTFC
 	aProcessorElement->appendChild(aRefLayerElement);
       }
     unsigned int iRefHit = 0;
-    for(unsigned int iRegion=0;iRegion<6;++iRegion){
-      xercesc::DOMElement* aRegionElement = theDoc->createElement(_toDOMS("LogicRegion"));
-      stringStr.str("");
-      stringStr<<iRegion;
-      aRegionElement->setAttribute(_toDOMS("iRegion"), _toDOMS(stringStr.str()));   
-      ////
+   
+    /////
+    ///////
       for(unsigned int iRefLayer=0;iRefLayer<OMTFConfiguration::nRefLayers;++iRefLayer){
+	for(unsigned int iRegion=0;iRegion<6;++iRegion){
 	for(unsigned int iInput=0;iInput<14;++iInput){
 	  unsigned int hitCount =  OMTFConfiguration::measurements4Dref[iProcessor][iRegion][iRefLayer][iInput];
 	  if(!hitCount) continue;
@@ -373,11 +371,8 @@ void  XMLConfigWriter::writeConnectionsData(const std::vector<std::vector <OMTFC
 	  //if(iRefHit<OMTFConfiguration::nRefHits) aProcessorElement->appendChild(aRefHitElement);
 	  if(iRefHit<128) aProcessorElement->appendChild(aRefHitElement);
 	  ++iRefHit;
-	}
-      }
-      //for(;iRegion==5 && iRefHit<OMTFConfiguration::nRefHits;++iRefHit){
-      for(;iRegion==5 && iRefHit<128;++iRefHit){
-
+	}	      
+      for(;iRegion==5 && iRefLayer==7 && iRefHit<OMTFConfiguration::nRefHits;++iRefHit){
 	xercesc::DOMElement* aRefHitElement = theDoc->createElement(_toDOMS("RefHit"));
 	stringStr.str("");
 	stringStr<<iRefHit;
@@ -407,8 +402,16 @@ void  XMLConfigWriter::writeConnectionsData(const std::vector<std::vector <OMTFC
 
 	aProcessorElement->appendChild(aRefHitElement);
       }
-    
+	}
+      }
+      
       ////
+      for(unsigned int iRegion=0;iRegion<6;++iRegion){
+	xercesc::DOMElement* aRegionElement = theDoc->createElement(_toDOMS("LogicRegion"));
+	stringStr.str("");
+	stringStr<<iRegion;
+	aRegionElement->setAttribute(_toDOMS("iRegion"), _toDOMS(stringStr.str()));   
+
       unsigned int iLayerNew = 0;
       for(unsigned int iLogicLayer=0;iLogicLayer<OMTFConfiguration::nLayers;++iLogicLayer){
 	if(removeLayers(iLogicLayer)) continue;

--- a/test/runOMTFPatternMaker.py
+++ b/test/runOMTFPatternMaker.py
@@ -4,9 +4,12 @@ import os
 import sys
 import commands
 
+verbose = False
+
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
-'''
-process.MessageLogger = cms.Service("MessageLogger",
+
+if verbose: 
+    process.MessageLogger = cms.Service("MessageLogger",
        suppressInfo       = cms.untracked.vstring('AfterSource', 'PostModule'),
        destinations   = cms.untracked.vstring(
                                              'detailedInfo'
@@ -50,10 +53,11 @@ process.MessageLogger = cms.Service("MessageLogger",
                 Alignment  = cms.untracked.PSet (limit = cms.untracked.int32(0) ), 
                 GetManyWithoutRegistration  = cms.untracked.PSet (limit = cms.untracked.int32(0) ), 
                 GetByLabelWithoutRegistration  = cms.untracked.PSet (limit = cms.untracked.int32(0) ) 
-       ),
-)
-'''
-process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(50000)
+                ),
+                                        )
+
+if not verbose:
+    process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(50000)
 process.options = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
 
 process.source = cms.Source(
@@ -67,13 +71,13 @@ process.source = cms.Source(
 ##Only for making the connections maps.
 process.source.fileNames =  cms.untracked.vstring()
 path = "/home/akalinow/scratch/CMS/OverlapTrackFinder/Crab/SingleMuFullEta/721_FullEta_v3/data/"
-command = "ls "+path+"/SingleMu_16_p_1*"
+command = "ls "+path+"/SingleMu_16_*_100_*"
 fileList = commands.getoutput(command).split("\n")
 process.source.fileNames =  cms.untracked.vstring()
 for aFile in fileList:
     process.source.fileNames.append('file:'+aFile)
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100000))
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1))
 
 ###PostLS1 geometry used
 process.load('Configuration.Geometry.GeometryExtendedPostLS1Reco_cff')
@@ -92,8 +96,8 @@ process.load('L1Trigger.L1TMuon.L1TMuonTriggerPrimitiveProducer_cfi')
 process.omtfPatternMaker = cms.EDAnalyzer("OMTFPatternMaker",
                                       TriggerPrimitiveSrc = cms.InputTag('L1TMuonTriggerPrimitives'),
                                       g4SimTrackSrc = cms.InputTag('g4SimHits'),
-                                      makeGoldenPatterns = cms.bool(True),                                     
-                                      makeConnectionsMaps = cms.bool(False),                                      
+                                      makeGoldenPatterns = cms.bool(False),                                     
+                                      makeConnectionsMaps = cms.bool(True),                                      
                                       dropRPCPrimitives = cms.bool(False),                                    
                                       dropDTPrimitives = cms.bool(False),                                    
                                       dropCSCPrimitives = cms.bool(False),   

--- a/test/runOMTFProducer.py
+++ b/test/runOMTFProducer.py
@@ -5,8 +5,11 @@ import sys
 import commands
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
-'''
-process.MessageLogger = cms.Service("MessageLogger",
+
+verbose = False
+
+if verobse:
+    process.MessageLogger = cms.Service("MessageLogger",
        suppressInfo       = cms.untracked.vstring('AfterSource', 'PostModule'),
        destinations   = cms.untracked.vstring(
                                              'detailedInfo'
@@ -50,18 +53,19 @@ process.MessageLogger = cms.Service("MessageLogger",
                 Alignment  = cms.untracked.PSet (limit = cms.untracked.int32(0) ), 
                 GetManyWithoutRegistration  = cms.untracked.PSet (limit = cms.untracked.int32(0) ), 
                 GetByLabelWithoutRegistration  = cms.untracked.PSet (limit = cms.untracked.int32(0) ) 
-       ),
-)
-'''
+                ),
+                                        )
 
-process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(10000)
+if not verbose:
+    process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(10000)
+
 process.options = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
 
 process.source = cms.Source(
     'PoolSource',
     fileNames = cms.untracked.vstring('file:/home/akalinow/scratch/CMS/OverlapTrackFinder/Crab/SingleMuFullEtaTestSample/720_FullEta_v1/data/SingleMu_16_p_1_2_TWz.root')
     )
-
+'''
 ##Use all available events in a single job.
 ##Only for making the connections maps.
 process.source.fileNames =  cms.untracked.vstring()
@@ -71,7 +75,7 @@ fileList = commands.getoutput(command).split("\n")
 process.source.fileNames =  cms.untracked.vstring()
 for aFile in fileList:
     process.source.fileNames.append('file:'+aFile)
-
+'''
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1))
 
 ###PostLS1 geometry used
@@ -97,10 +101,7 @@ process.omtfEmulator = cms.EDProducer("OMTFProducer",
                                       dropDTPrimitives = cms.bool(False),                                    
                                       dropCSCPrimitives = cms.bool(False),   
                                       omtf = cms.PSet(
-        #configXMLFile = cms.string(path+"hwToLogicLayer.xml"),
-        #patternsXMLFiles = cms.vstring(path+"Patterns_chPlus.xml",path+"Patterns_chMinus.xml"),
-
-        configXMLFile = cms.string(path+"hwToLogicLayer_18layersFix2.xml"),
+        configXMLFile = cms.string(path+"hwToLogicLayer_721_03_02_2015.xml"),
         patternsXMLFiles = cms.vstring(path+"Patterns_ipt6_18.xml",path+"Patterns_ipt19_31.xml"),
 
         )


### PR DESCRIPTION
Pierwsza wersja sortera z ghostbusterem: akceptowanych jest do trzech kandydatow na procesor o roznym phi (5deg = half of logic cone size = 5/360*4096=57"logic strips") lub roznym znaku.
Dodatkowo wszystkie zmiany z tagu 03_02_2015 ktore nie weszly do brancha Emulator